### PR TITLE
Add inventory command

### DIFF
--- a/escape.py
+++ b/escape.py
@@ -4,7 +4,11 @@
 def main():
     print("Welcome to Escape the Terminal")
     print("Type 'help' for a list of commands. Type 'quit' to exit.")
-    location_description = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    location_description = (
+        "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    )
+    room_items = ["access.key"]
+    inventory = []
     while True:
         try:
             cmd = input('> ').strip().lower()
@@ -12,9 +16,24 @@ def main():
             print()
             break
         if cmd == 'help':
-            print("Available commands: help, look, quit")
+            print("Available commands: help, look, take <item>, inventory, quit")
         elif cmd == 'look':
             print(location_description)
+            if room_items:
+                print("You see: " + ", ".join(room_items))
+        elif cmd.startswith('take '):
+            item = cmd.split(' ', 1)[1]
+            if item in room_items:
+                room_items.remove(item)
+                inventory.append(item)
+                print(f"You pick up the {item}.")
+            else:
+                print(f"There is no {item} here.")
+        elif cmd == 'inventory':
+            if inventory:
+                print("Inventory: " + ", ".join(inventory))
+            else:
+                print("Inventory is empty.")
         elif cmd in ('quit', 'exit'):
             print("Goodbye")
             break

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -20,4 +20,28 @@ def test_look_command():
         capture_output=True,
     )
     assert 'dimly lit terminal' in result.stdout
+    assert 'access.key' in result.stdout
+    assert 'Goodbye' in result.stdout
+
+
+def test_inventory_empty():
+    result = subprocess.run(
+        [sys.executable, 'escape.py'],
+        input='inventory\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'Inventory is empty' in result.stdout
+    assert 'Goodbye' in result.stdout
+
+
+def test_take_item_and_inventory():
+    result = subprocess.run(
+        [sys.executable, 'escape.py'],
+        input='take access.key\ninventory\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'pick up the access.key' in result.stdout
+    assert 'Inventory: access.key' in result.stdout
     assert 'Goodbye' in result.stdout


### PR DESCRIPTION
## Summary
- add simple inventory system
- implement `take` command and show items on `look`
- expand tests for inventory and item interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854af009998832a8a83c18418ed360f