### PR TITLE
Add save/load system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project is a minimalist terminal game. For the long-term vision, see [VISIO
    Use `help` (or `h`) inside the game for available commands and `quit` (or `exit`) to exit.
    Common command aliases like `i`/`inv` for `inventory` and `look around` for `look` are also supported.
    The `use <item>` command lets you interact with objects in your inventory.
+   Use `save` to write your progress to `game.sav` and `load` to restore it.
 
 ## Running Tests
 Tests require `pytest` and can be executed with:

--- a/escape.py
+++ b/escape.py
@@ -21,11 +21,12 @@ class Game:
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view."
         }
+        self.save_file = "game.sav"
 
     def _print_help(self):
         print(
             "Available commands: help, look, take <item>, inventory, "
-            "examine <item>, use <item>, quit"
+            "examine <item>, use <item>, save, load, quit"
         )
 
     def _look(self):
@@ -64,6 +65,37 @@ class Game:
         else:
             print(f"You can't use {item} right now.")
 
+    def _save(self):
+        data = {
+            "room_items": self.room_items,
+            "inventory": self.inventory,
+        }
+        try:
+            with open(self.save_file, "w", encoding="utf-8") as f:
+                import json
+
+                json.dump(data, f)
+        except OSError as e:
+            print(f"Failed to save: {e}")
+        else:
+            print("Game saved.")
+
+    def _load(self):
+        import json
+
+        try:
+            with open(self.save_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            print("No save file found.")
+            return
+        except OSError as e:
+            print(f"Failed to load: {e}")
+            return
+        self.room_items = data.get("room_items", [])
+        self.inventory = data.get("inventory", [])
+        print("Game loaded.")
+
     def run(self):
         print("Welcome to Escape the Terminal")
         print("Type 'help' for a list of commands. Type 'quit' to exit.")
@@ -88,6 +120,10 @@ class Game:
             elif cmd.startswith('use '):
                 item = cmd.split(' ', 1)[1]
                 self._use(item)
+            elif cmd == 'save':
+                self._save()
+            elif cmd == 'load':
+                self._load()
             elif cmd in ('quit', 'exit'):
                 print("Goodbye")
                 break

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,12 @@
 import subprocess, sys
+import os
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'escape.py')
 
 
 def test_quit_command():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='quit\n',
         text=True,
         capture_output=True,
@@ -14,7 +17,7 @@ def test_quit_command():
 
 def test_look_command():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='look\nquit\n',
         text=True,
         capture_output=True,
@@ -26,7 +29,7 @@ def test_look_command():
 
 def test_inventory_empty():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='inventory\nquit\n',
         text=True,
         capture_output=True,
@@ -37,7 +40,7 @@ def test_inventory_empty():
 
 def test_take_item_and_inventory():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='take access.key\ninventory\nquit\n',
         text=True,
         capture_output=True,
@@ -49,7 +52,7 @@ def test_take_item_and_inventory():
 
 def test_examine_item():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='examine access.key\nquit\n',
         text=True,
         capture_output=True,
@@ -60,7 +63,7 @@ def test_examine_item():
 
 def test_examine_missing_item():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='examine unknown\nquit\n',
         text=True,
         capture_output=True,
@@ -71,7 +74,7 @@ def test_examine_missing_item():
 
 def test_inventory_alias_i():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='i\nquit\n',
         text=True,
         capture_output=True,
@@ -82,7 +85,7 @@ def test_inventory_alias_i():
 
 def test_inventory_alias_inv():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='inv\nquit\n',
         text=True,
         capture_output=True,
@@ -93,7 +96,7 @@ def test_inventory_alias_inv():
 
 def test_look_around_alias():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='look around\nquit\n',
         text=True,
         capture_output=True,
@@ -104,7 +107,7 @@ def test_look_around_alias():
 
 def test_help_alias():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='h\nquit\n',
         text=True,
         capture_output=True,
@@ -115,7 +118,7 @@ def test_help_alias():
 
 def test_use_item_missing():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='use access.key\nquit\n',
         text=True,
         capture_output=True,
@@ -126,7 +129,7 @@ def test_use_item_missing():
 
 def test_use_item_after_take():
     result = subprocess.run(
-        [sys.executable, 'escape.py'],
+        [sys.executable, SCRIPT],
         input='take access.key\nuse access.key\nquit\n',
         text=True,
         capture_output=True,
@@ -134,3 +137,27 @@ def test_use_item_after_take():
     assert 'pick up the access.key' in result.stdout
     assert 'hidden directory flickers' in result.stdout
     assert 'Goodbye' in result.stdout
+
+
+def test_save_and_load(tmp_path):
+    save_file = tmp_path / 'game.sav'
+
+    # take item and save the game
+    subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take access.key\nsave\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+    )
+    assert save_file.exists()
+
+    # load the game and check inventory
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='load\ninventory\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+    )
+    assert 'Inventory: access.key' in result.stdout


### PR DESCRIPTION
## Summary
- implement `save` and `load` commands to persist game state
- document save/load in README
- update tests to use script path and cover save/load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b18c76bc832aa20aed9b3995d39c