### PR TITLE
Add cat command for reading narrative files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+!data/voice.log

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project is a minimalist terminal game. For the long-term vision, see [VISIO
    Items can be discarded with `drop <item>`.
    Navigate the world as if it were a filesystem using `ls` to list the
    contents of the current room and `cd <dir>` to move between rooms.
+   Use `cat <file>` to read narrative logs stored under the `data` directory.
    Use `save` to write your progress to `game.sav` and `load` to restore it.
 
 ## Running Tests

--- a/data/voice.log
+++ b/data/voice.log
@@ -1,0 +1,1 @@
+You hear a faint digital voice whispering from beyond the code.

--- a/escape.py
+++ b/escape.py
@@ -4,6 +4,8 @@ This module now exposes a :class:`Game` object to make future expansion
 easier while preserving the original command-line interface.
 """
 
+from pathlib import Path
+
 
 class Game:
     """Simple command dispatcher for the terminal adventure."""
@@ -33,11 +35,12 @@ class Game:
             "access.key": "The key hums softly and a hidden directory flickers into view."
         }
         self.save_file = "game.sav"
+        self.data_dir = Path(__file__).parent / "data"
 
     def _print_help(self):
         print(
             "Available commands: help, look, ls, cd <dir>, take <item>, drop <item>, "
-            "inventory, examine <item>, use <item>, save, load, quit"
+            "inventory, examine <item>, use <item>, cat <file>, save, load, quit"
         )
 
     def _current_node(self):
@@ -94,6 +97,19 @@ class Game:
             print(msg)
         else:
             print(f"You can't use {item} right now.")
+
+    def _cat(self, filename: str):
+        path = self.data_dir / filename
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+        except FileNotFoundError:
+            print(f"No such file: {filename}")
+            return
+        except OSError as e:
+            print(f"Failed to read {filename}: {e}")
+            return
+        print(text.rstrip())
 
     def _ls(self):
         node = self._current_node()
@@ -183,6 +199,9 @@ class Game:
             elif cmd.startswith('use '):
                 item = cmd.split(' ', 1)[1]
                 self._use(item)
+            elif cmd.startswith('cat '):
+                filename = cmd.split(' ', 1)[1]
+                self._cat(filename)
             elif cmd == 'save':
                 self._save()
             elif cmd == 'load':

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -188,3 +188,14 @@ def test_ls_and_cd():
     assert 'treasure.txt' in out
     assert out.count('hidden/') >= 1
     assert 'Goodbye' in out
+
+
+def test_cat_command():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cat voice.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'faint digital voice' in result.stdout
+    assert 'Goodbye' in result.stdout


### PR DESCRIPTION
## Summary
- implement `Game._cat` for reading files in a new `data` directory
- parse `cat <file>` in the command loop
- update help and README with the new command
- add `voice.log` narrative file
- test `cat` command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b8c14e00832a8c6c7bf208914fbd