### PR TITLE
Add new puzzle items and unlockable directory

### DIFF
--- a/data/mem.fragment
+++ b/data/mem.fragment
@@ -1,0 +1,1 @@
+The data is corrupted but you catch glimpses of your own past.

--- a/escape.py
+++ b/escape.py
@@ -12,27 +12,31 @@ class Game:
 
     def __init__(self):
         self.inventory = []
+        # base filesystem state; the hidden directory is injected when unlocked
+        self.hidden_dir = {
+            "desc": "A directory shrouded in mystery.",
+            "items": ["mem.fragment", "treasure.txt"],
+            "dirs": {},
+        }
         self.fs = {
             "desc": (
                 "You find yourself in a dimly lit terminal session. "
                 "The prompt blinks patiently."
             ),
-            "items": ["access.key"],
-            "dirs": {
-                "hidden": {
-                    "desc": "A directory shrouded in mystery.",
-                    "items": ["treasure.txt"],
-                    "dirs": {},
-                }
-            },
+            "items": ["access.key", "voice.log"],
+            "dirs": {},
         }
         self.current = []  # path as list of directory names
         self.item_descriptions = {
             "access.key": "A slim digital token rumored to unlock hidden directories.",
             "treasure.txt": "A file filled with untold riches.",
+            "mem.fragment": "A corrupted memory fragment pulsing faintly with data.",
+            "voice.log": "An audio log that might contain a clue.",
         }
         self.use_messages = {
-            "access.key": "The key hums softly and a hidden directory flickers into view."
+            "access.key": "The key hums softly and a hidden directory flickers into view.",
+            "mem.fragment": "Fragments of your past flash before your eyes.",
+            "voice.log": "A haunting voice whispers: 'Find the fragment.'",
         }
         self.save_file = "game.sav"
         self.data_dir = Path(__file__).parent / "data"
@@ -92,6 +96,10 @@ class Game:
         if item not in self.inventory:
             print(f"You do not have {item} to use.")
             return
+        if item == "access.key":
+            root = self.fs
+            if "hidden" not in root["dirs"]:
+                root["dirs"]["hidden"] = self.hidden_dir
         msg = self.use_messages.get(item)
         if msg:
             print(msg)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -24,6 +24,7 @@ def test_look_command():
     )
     assert 'dimly lit terminal' in result.stdout
     assert 'access.key' in result.stdout
+    assert 'voice.log' in result.stdout
     assert 'Goodbye' in result.stdout
 
 
@@ -179,11 +180,12 @@ def test_save_and_load(tmp_path):
 def test_ls_and_cd():
     result = subprocess.run(
         [sys.executable, SCRIPT],
-        input='ls\ncd hidden\nls\ncd ..\nls\nquit\n',
+        input='ls\ntake access.key\nuse access.key\nls\ncd hidden\nls\ncd ..\nls\nquit\n',
         text=True,
         capture_output=True,
     )
     out = result.stdout
+    # first ls should not show hidden, final ones should
     assert 'hidden/' in out
     assert 'treasure.txt' in out
     assert out.count('hidden/') >= 1
@@ -198,4 +200,26 @@ def test_cat_command():
         capture_output=True,
     )
     assert 'faint digital voice' in result.stdout
+    assert 'Goodbye' in result.stdout
+
+
+def test_use_voice_log():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take voice.log\nuse voice.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'haunting voice' in result.stdout
+    assert 'Goodbye' in result.stdout
+
+
+def test_examine_mem_fragment():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take access.key\nuse access.key\ncd hidden\nexamine mem.fragment\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'corrupted memory fragment' in result.stdout
     assert 'Goodbye' in result.stdout


### PR DESCRIPTION
## Summary
- introduce `mem.fragment` and `voice.log` items with descriptions and use text
- hide `hidden/` directory until player uses `access.key`
- support saving/loading of new state naturally
- add data file for `mem.fragment`
- expand tests for new interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ba9e2b6c832aa959ebb65433a3c3