### PR TITLE
Add treasure file and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ unexpected ways.
    - `save` / `load` – write and restore your progress to `game.sav`
    - `glitch` – toggle glitch mode for scrambled descriptions
 
+   **Core files/items**
+   - `access.key` – unlocks the hidden directory when used
+   - `voice.log` – whispers a clue when read
+   - `mem.fragment` – a corrupted memory chunk found in `hidden/`
+   - `treasure.txt` – reward text tucked away in `hidden/`
+
 ## Running Tests
 Tests are written with `pytest` and live under the `tests/` directory. After installing
 the requirements, simply run `pytest` from the project root:

--- a/data/treasure.txt
+++ b/data/treasure.txt
@@ -1,0 +1,1 @@
+You discover a stash of credits and a map leading out of the terminal.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -225,6 +225,20 @@ def test_examine_mem_fragment():
     assert 'Goodbye' in result.stdout
 
 
+def test_cat_treasure_after_unlock():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take access.key\nuse access.key\ncd hidden\ncat treasure.txt\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert (
+        'You discover a stash of credits and a map leading out of the terminal.'
+        in result.stdout
+    )
+    assert 'Goodbye' in result.stdout
+
+
 def test_glitch_mode_toggle():
     expected = (
         'You find yourself in a dimly lit t&*minal session. T*e pr@m@t blin&s patiently.'


### PR DESCRIPTION
## Summary
- add `data/treasure.txt` with reward text
- document key game assets in README
- test reading the treasure file after unlocking hidden directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bf1e2e80832a98303947c3e33d5d