### PR TITLE
Add target-specific 'use' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ unexpected ways.
    - `take <item>` / `drop <item>` – manage inventory items
    - `inventory` / `i` / `inv` – show what you're carrying
    - `examine <item>` – get a closer look at an object
-   - `use <item>` – interact with items (e.g. the `access.key` reveals hidden areas)
+  - `use <item> [on <target>]` – interact with items (e.g. `use access.key on door` reveals hidden areas)
    - `ls` – list directories and items in the current location
    - `cd <dir>` – move between directories/rooms
    - `cat <file>` – read narrative logs from `data/`
@@ -33,7 +33,7 @@ unexpected ways.
    - `glitch` – toggle glitch mode for scrambled descriptions
 
    **Core files/items**
-   - `access.key` – unlocks the hidden directory when used
+  - `access.key` – unlocks the hidden directory when used on the door
    - `voice.log` – whispers a clue when read
    - `mem.fragment` – a corrupted memory chunk found in `hidden/`
    - `treasure.txt` – reward text tucked away in `hidden/`

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -140,6 +140,19 @@ def test_use_item_after_take():
     assert 'Goodbye' in result.stdout
 
 
+def test_use_item_on_door():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take access.key\nuse access.key on door\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'hidden directory flickers' in out
+    assert 'hidden/' in out
+    assert 'Goodbye' in out
+
+
 def test_drop_item():
     result = subprocess.run(
         [sys.executable, SCRIPT],


### PR DESCRIPTION
## Summary
- support `use ITEM on TARGET` command parsing
- handle item-target logic in `_use`
- mention new syntax in command help and README
- test unlocking hidden door with `use access.key on door`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c0d301bc832ab6c1af7736ab7be6