### PR TITLE
Add daemon NPC interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 !data/voice.log
+!data/daemon.log

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ unexpected ways.
    - `voice.log` – whispers a clue when read
    - `mem.fragment` – a corrupted memory chunk found in `hidden/`
    - `treasure.txt` – reward text tucked away in `hidden/`
-   - `decoder` – located in the `lab/` directory
-   - `old.note` – stashed away in the `archive/` directory
+  - `decoder` – located in the `lab/` directory
+  - `old.note` – stashed away in the `archive/` directory
+  - `daemon.log` – consult the system daemon when read or used, found in `core/npc/`
 
    **Rooms**
    - `lab/` – a cluttered research area humming with equipment
-   - `archive/` – dusty shelves of old backups and forgotten notes
+  - `archive/` – dusty shelves of old backups and forgotten notes
+  - `core/npc/` – a secluded nook where a daemon awaits interaction
 
 ## Running Tests
 Tests are written with `pytest` and live under the `tests/` directory. After installing

--- a/data/daemon.log
+++ b/data/daemon.log
@@ -1,0 +1,1 @@
+A low-level daemon monitors your actions.

--- a/escape.py
+++ b/escape.py
@@ -35,6 +35,17 @@ class Game:
                     "items": ["old.note"],
                     "dirs": {},
                 },
+                "core": {
+                    "desc": "The core systems thrum with latent energy.",
+                    "items": [],
+                    "dirs": {
+                        "npc": {
+                            "desc": "A quiet daemon lingers here, waiting to be addressed.",
+                            "items": ["daemon.log"],
+                            "dirs": {},
+                        }
+                    },
+                },
             },
         }
         self.current = []  # path as list of directory names
@@ -45,11 +56,13 @@ class Game:
             "voice.log": "An audio log that might contain a clue.",
             "decoder": "A handheld device used to decode encrypted signals.",
             "old.note": "A weathered note scribbled with barely readable commands.",
+            "daemon.log": "A log file chronicling the mutterings of a resident daemon.",
         }
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view.",
             "mem.fragment": "Fragments of your past flash before your eyes.",
             "voice.log": "A haunting voice whispers: 'Find the fragment.'",
+            "daemon.log": "The daemon rasps from deep within the system: 'Keep your code clean.'",
         }
         self.save_file = "game.sav"
         self.data_dir = Path(__file__).parent / "data"
@@ -168,6 +181,10 @@ class Game:
             self._output(f"Failed to read {filename}: {e}")
             return
         self._output(text.rstrip())
+        if filename == "daemon.log":
+            msg = self.use_messages.get("daemon.log")
+            if msg:
+                self._output(msg)
 
     def _ls(self):
         node = self._current_node()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -240,6 +240,32 @@ def test_use_voice_log():
     assert 'Goodbye' in result.stdout
 
 
+def test_cat_daemon_log():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd core\ncd npc\ncat daemon.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'daemon monitors your actions' in out
+    assert 'Keep your code clean' in out
+    assert 'Goodbye' in out
+
+
+def test_use_daemon_log():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd core\ncd npc\ntake daemon.log\nuse daemon.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'pick up the daemon.log' in out
+    assert 'Keep your code clean' in out
+    assert 'Goodbye' in out
+
+
 def test_examine_mem_fragment():
     result = subprocess.run(
         [sys.executable, SCRIPT],


### PR DESCRIPTION
## Summary
- extend filesystem with `core/npc` directory
- add `daemon.log` item and dialogue when read or used
- expose daemon lines via `cat` and `use`
- test new NPC dialogue interactions
- document daemon in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c1a7f69c832ab62194ecee56a257