### PR TITLE
Add dream and memory directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ cython_debug/
 .cursorindexingignore
 !data/voice.log
 !data/daemon.log
+!data/flashback.log

--- a/data/flashback.log
+++ b/data/flashback.log
@@ -1,0 +1,1 @@
+Fragments of old memories scroll by, hinting at choices you once made.

--- a/data/lucid.note
+++ b/data/lucid.note
@@ -1,0 +1,1 @@
+The note reads: "In dreams you may chart the path to awakening."

--- a/escape.py
+++ b/escape.py
@@ -46,6 +46,16 @@ class Game:
                         }
                     },
                 },
+                "dream": {
+                    "desc": "A hazy directory where reality blurs and ideas take shape.",
+                    "items": ["lucid.note"],
+                    "dirs": {},
+                },
+                "memory": {
+                    "desc": "Stacks of recollections archived for later reflection.",
+                    "items": ["flashback.log"],
+                    "dirs": {},
+                },
             },
         }
         self.current = []  # path as list of directory names
@@ -57,12 +67,16 @@ class Game:
             "decoder": "A handheld device used to decode encrypted signals.",
             "old.note": "A weathered note scribbled with barely readable commands.",
             "daemon.log": "A log file chronicling the mutterings of a resident daemon.",
+            "lucid.note": "A scribbled note describing techniques for conscious dreaming.",
+            "flashback.log": "A recorded memory playback waiting to be relived.",
         }
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view.",
             "mem.fragment": "Fragments of your past flash before your eyes.",
             "voice.log": "A haunting voice whispers: 'Find the fragment.'",
             "daemon.log": "The daemon rasps from deep within the system: 'Keep your code clean.'",
+            "lucid.note": "The words resonate, sharpening your awareness of the dream.",
+            "flashback.log": "Memories surge forth, revealing forgotten paths.",
         }
         self.save_file = "game.sav"
         self.data_dir = Path(__file__).parent / "data"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -205,6 +205,19 @@ def test_ls_and_cd():
     assert 'Goodbye' in out
 
 
+def test_root_contains_dream_and_memory():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='ls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'dream/' in out
+    assert 'memory/' in out
+    assert 'Goodbye' in out
+
+
 def test_pwd_command():
     result = subprocess.run(
         [sys.executable, SCRIPT],
@@ -262,6 +275,30 @@ def test_cat_daemon_log():
     out = result.stdout
     assert 'daemon monitors your actions' in out
     assert 'Keep your code clean' in out
+    assert 'Goodbye' in out
+
+
+def test_cat_lucid_note():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\ncat lucid.note\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'dreams you may chart' in out
+    assert 'Goodbye' in out
+
+
+def test_cat_flashback_log():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd memory\ncat flashback.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'old memories scroll' in out
     assert 'Goodbye' in out
 
 


### PR DESCRIPTION
## Summary
- expand initial filesystem with `dream/` and `memory/` directories
- add new items `lucid.note` and `flashback.log`
- include descriptions and use messages for the new items
- provide narrative text for the new data files
- test listing new directories and reading the new files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c622a7d4832abf72456a3d70be9f