### PR TITLE
Generate random dream directories

### DIFF
--- a/escape.py
+++ b/escape.py
@@ -70,6 +70,8 @@ class Game:
             "lucid.note": "A scribbled note describing techniques for conscious dreaming.",
             "flashback.log": "A recorded memory playback waiting to be relived.",
         }
+        # populate the dream directory with extra procedurally generated content
+        self._generate_extra_dirs()
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view.",
             "mem.fragment": "Fragments of your past flash before your eyes.",
@@ -82,6 +84,38 @@ class Game:
         self.data_dir = Path(__file__).parent / "data"
         self.glitch_mode = False
         self.glitch_steps = 0
+
+    def _generate_extra_dirs(self, base: str = "dream") -> None:
+        """Populate ``base`` directory with random subdirectories."""
+        import os
+        import random
+
+        seed_val = os.getenv("ET_EXTRA_SEED")
+        rnd = random.Random(int(seed_val)) if seed_val is not None else random.Random()
+
+        base_node = self.fs["dirs"].get(base)
+        if not base_node:
+            return
+
+        adjectives = ["misty", "vivid", "neon", "echoing"]
+        nouns = ["hall", "nexus", "alcove", "node"]
+        item_defs = [
+            ("dream.shard", "A sliver of surreal memory."),
+            ("echo.bit", "An echo of a forgotten idea."),
+            ("vision.chip", "A chip flickering with ephemeral scenes."),
+        ]
+
+        count = rnd.randint(2, 3)
+        for idx in range(count):
+            dname = f"{rnd.choice(adjectives)}_{rnd.choice(nouns)}_{idx}"
+            desc = f"A {rnd.choice(['strange', 'fleeting', 'curious'])} place within the dream."
+            items: list[str] = []
+            if rnd.random() < 0.5:
+                it_name, it_desc = rnd.choice(item_defs)
+                it_name = it_name.replace(".", f"{idx}.")
+                items.append(it_name)
+                self.item_descriptions[it_name] = it_desc
+            base_node["dirs"][dname] = {"desc": desc, "items": items, "dirs": {}}
 
     def _toggle_glitch(self):
         self.glitch_mode = not self.glitch_mode

--- a/tests/test_extra_dirs.py
+++ b/tests/test_extra_dirs.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'escape.py')
+
+
+def test_extra_dirs_with_seed():
+    env = os.environ.copy()
+    env['ET_EXTRA_SEED'] = '123'
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\nls\ncd neon_hall_0\nls\nquit\n',
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    out = result.stdout
+    assert 'neon_hall_0/' in out
+    assert 'echoing_alcove_1/' in out
+    assert 'dream0.shard' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add `_generate_extra_dirs` helper for dream subdirectories
- call the generator during game initialization
- respect `ET_EXTRA_SEED` env var for deterministic generation
- test directory generation with fixed seed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c8d82258832a91a22015905ffdeb