### PR TITLE
Add packaging and entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ unexpected ways.
 
 ## Setup
 1. Install Python 3.
-2. Install dependencies:
+2. Install the project in editable mode:
    ```bash
-   pip install -r requirements.txt
+   pip install -e .
    ```
-3. Run the game:
+3. Run the game using the console entry point:
    ```bash
-   python escape.py
+   escape-terminal
    ```
    Use `help` (or `h`) inside the game for available commands and `quit` (or `exit`) to exit.
    Common command aliases like `i`/`inv` for `inventory` and `look around` for `look` are also supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "escape-the-terminal"
+version = "0.1.0"
+description = "A retro cybertext adventure in the terminal."
+readme = "README.md"
+authors = [{name="EscapeTheTerminal Contributors"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+
+[project.scripts]
+escape-terminal = "escape:main"
+
+[tool.setuptools]
+py-modules = ["escape"]
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+
+def test_console_script_invocation():
+    # Install the project in editable mode
+    subprocess.run(
+        [sys.executable, '-m', 'pip', 'install', '-e', '.', '--no-deps', '--quiet'],
+        check=True,
+    )
+    result = subprocess.run(
+        ['escape-terminal'],
+        input='quit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'Goodbye' in result.stdout
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- package the project via `pyproject.toml`
- document installation and usage of the new console script
- add a test ensuring the entrypoint works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ca8076d0832aaa35fdf3c0b32e5d