### PR TITLE
Refactor command dispatch with registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ pytest
 ```
 Use `pytest tests/test_basic.py::test_name` to execute an individual test during
 development.
+
+## Command Registry
+Commands are routed through the ``Game.command_map`` dictionary. Each command
+string or alias maps to a handler method. When adding a new command simply
+register it in ``command_map`` with a callable that accepts the raw argument
+string. The main loop will pass any text following the command name to the
+handler automatically.


### PR DESCRIPTION
## Summary
- refactor `Game.run` to use a `command_map` registry
- add helper for parsing the `use` command and implement `_quit`
- document the registry for contributors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cc529b44832a91c87229d5f104eb