### PR TITLE
Add dream subdirectory and hidden vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ cython_debug/
 !data/voice.log
 !data/daemon.log
 !data/flashback.log
+!data/reverie.log
+!data/escape.plan

--- a/data/escape.plan
+++ b/data/escape.plan
@@ -1,0 +1,1 @@
+A meticulous route scribbled out of sight, promising freedom.

--- a/data/reverie.log
+++ b/data/reverie.log
@@ -1,0 +1,1 @@
+Traces of reveries swirl here, blurring wakefulness and code.

--- a/escape.py
+++ b/escape.py
@@ -16,7 +16,13 @@ class Game:
         self.hidden_dir = {
             "desc": "A directory shrouded in mystery.",
             "items": ["mem.fragment", "treasure.txt"],
-            "dirs": {},
+            "dirs": {
+                "vault": {
+                    "desc": "A locked vault storing plans best kept secret.",
+                    "items": ["escape.plan"],
+                    "dirs": {},
+                }
+            },
         }
         self.fs = {
             "desc": (
@@ -49,7 +55,13 @@ class Game:
                 "dream": {
                     "desc": "A hazy directory where reality blurs and ideas take shape.",
                     "items": ["lucid.note"],
-                    "dirs": {},
+                    "dirs": {
+                        "subconscious": {
+                            "desc": "Half-formed thoughts linger here, waiting to be read.",
+                            "items": ["reverie.log"],
+                            "dirs": {},
+                        }
+                    },
                 },
                 "memory": {
                     "desc": "Stacks of recollections archived for later reflection.",
@@ -69,6 +81,8 @@ class Game:
             "daemon.log": "A log file chronicling the mutterings of a resident daemon.",
             "lucid.note": "A scribbled note describing techniques for conscious dreaming.",
             "flashback.log": "A recorded memory playback waiting to be relived.",
+            "reverie.log": "A log capturing fleeting reveries within the system.",
+            "escape.plan": "A hastily sketched route promising a way out.",
         }
         # populate the dream directory with extra procedurally generated content
         self._generate_extra_dirs()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -388,3 +388,40 @@ def test_talk_daemon():
     assert 'acknowledges your presence' in out
     assert 'more to learn' in out
     assert 'Goodbye' in out
+
+
+def test_dream_contains_subconscious():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'subconscious/' in out
+    assert 'Goodbye' in out
+
+
+def test_reverie_log_present():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\ncd subconscious\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'reverie.log' in out
+    assert 'Goodbye' in out
+
+
+def test_hidden_vault_and_escape_plan():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='take access.key\nuse access.key\ncd hidden\nls\ncd vault\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'vault/' in out
+    assert 'escape.plan' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- expand `dream` directory with `subconscious` subfolder
- add `vault` folder to the hidden area
- describe new `reverie.log` and `escape.plan` items
- include new narrative files
- test new locations and items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cd45c14c832a90432c06f0ff61a4