### PR TITLE
Improve documentation for new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ drive exploration, and commands like `use` or `glitch` advance the story in
 unexpected ways.
 
 ## Setup
-1. Install Python 3.
-2. Install the project in editable mode:
+1. Install Python 3.8 or higher.
+2. Install the project in editable mode (including optional test extras):
    ```bash
-   pip install -e .
+   pip install -e '.[test]'
    ```
 3. Run the game using the console entry point:
    ```bash
@@ -29,6 +29,7 @@ unexpected ways.
    - `ls` – list directories and items in the current location
    - `cd <dir>` – move between directories/rooms
    - `cat <file>` – read narrative logs from `data/`
+   - `talk <npc>` – initiate conversation and choose numbered replies
   - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
   - `glitch` – toggle glitch mode for scrambled descriptions. The longer it
     stays active the stronger the corruption becomes and occasional glitch
@@ -68,8 +69,8 @@ handler automatically.
 NPC conversations are stored under ``data/npc`` using the naming scheme
 ``<name>.dialog``. The ``talk <name>`` command will load the matching file if the
 player is in the correct directory for that NPC. Lines beginning with ``>`` are
-treated as simple menu options and will be displayed as a numbered list for the
-player to choose from. A minimal ``dreamer.dialog`` might look like:
+treated as simple menu options. They appear as a numbered list and you select a
+reply by typing its number. A minimal ``dreamer.dialog`` might look like:
 
 ```
 The dreamer watches you closely.

--- a/VISIONDOCUMENT.md
+++ b/VISIONDOCUMENT.md
@@ -93,6 +93,14 @@ Endings include:
 
 ---
 
+## ✨ Expanded Narrative Scope
+
+The world now includes optional side quests and branching conversations with NPCs.
+Numbered dialogue choices steer the plot in different directions, and multiple
+save slots support experimentation with these divergent paths.
+
+---
+
 ## 🗺 Future Ideas
 
 * Procedural directory tree generation (`/dream`, `/memory`, `/core`, `/logs`)


### PR DESCRIPTION
## Summary
- document installation extras
- mention talk command with numbered responses and save slots
- describe expanded narrative scope in the vision document

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d2f63a14832a90b497b4c789c0c0