### PR TITLE
Expand extra dir generation across multiple bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ pytest
 Use `pytest tests/test_basic.py::test_name` to execute an individual test during
 development.
 
+## Procedural Directories
+The game randomly adds extra subdirectories to several base areas on startup.
+By default the `dream/`, `memory/` and `core/` directories each receive two or
+three generated locations, sometimes containing unique items. Set the
+`ET_EXTRA_SEED` environment variable before launching to make this generation
+deterministic for reproducible testing or custom scenarios.
+
 ## Command Registry
 Commands are routed through the ``Game.command_map`` dictionary. Each command
 string or alias maps to a handler method. When adding a new command simply

--- a/escape.py
+++ b/escape.py
@@ -93,8 +93,8 @@ class Game:
             "reverie.log": "A log capturing fleeting reveries within the system.",
             "escape.plan": "A hastily sketched route promising a way out.",
         }
-        # populate the dream directory with extra procedurally generated content
-        self._generate_extra_dirs()
+        # populate multiple directories with extra procedurally generated content
+        self._generate_extra_dirs(["dream", "memory", "core"])
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view.",
             "mem.fragment": "Fragments of your past flash before your eyes.",
@@ -133,17 +133,16 @@ class Game:
             "exit": lambda arg="": self._quit(),
         }
 
-    def _generate_extra_dirs(self, base: str = "dream") -> None:
-        """Populate ``base`` directory with random subdirectories."""
+    def _generate_extra_dirs(self, bases: list[str] | str = "dream") -> None:
+        """Populate directories under each base path with random subdirectories."""
         import os
         import random
 
+        if isinstance(bases, str):
+            bases = [bases]
+
         seed_val = os.getenv("ET_EXTRA_SEED")
         rnd = random.Random(int(seed_val)) if seed_val is not None else random.Random()
-
-        base_node = self.fs["dirs"].get(base)
-        if not base_node:
-            return
 
         adjectives = ["misty", "vivid", "neon", "echoing"]
         nouns = ["hall", "nexus", "alcove", "node"]
@@ -152,18 +151,24 @@ class Game:
             ("echo.bit", "An echo of a forgotten idea."),
             ("vision.chip", "A chip flickering with ephemeral scenes."),
         ]
+        for base in bases:
+            base_node = self.fs["dirs"].get(base)
+            if not base_node:
+                continue
 
-        count = rnd.randint(2, 3)
-        for idx in range(count):
-            dname = f"{rnd.choice(adjectives)}_{rnd.choice(nouns)}_{idx}"
-            desc = f"A {rnd.choice(['strange', 'fleeting', 'curious'])} place within the dream."
-            items: list[str] = []
-            if rnd.random() < 0.5:
-                it_name, it_desc = rnd.choice(item_defs)
-                it_name = it_name.replace(".", f"{idx}.")
-                items.append(it_name)
-                self.item_descriptions[it_name] = it_desc
-            base_node["dirs"][dname] = {"desc": desc, "items": items, "dirs": {}}
+            count = rnd.randint(2, 3)
+            for idx in range(count):
+                dname = f"{rnd.choice(adjectives)}_{rnd.choice(nouns)}_{idx}"
+                desc = (
+                    f"A {rnd.choice(['strange', 'fleeting', 'curious'])} place within the dream."
+                )
+                items: list[str] = []
+                if rnd.random() < 0.5:
+                    it_name, it_desc = rnd.choice(item_defs)
+                    it_name = it_name.replace(".", f"{idx}.")
+                    items.append(it_name)
+                    self.item_descriptions[it_name] = it_desc
+                base_node["dirs"][dname] = {"desc": desc, "items": items, "dirs": {}}
 
     def _toggle_glitch(self):
         self.glitch_mode = not self.glitch_mode

--- a/tests/test_extra_dirs.py
+++ b/tests/test_extra_dirs.py
@@ -10,7 +10,10 @@ def test_extra_dirs_with_seed():
     env['ET_EXTRA_SEED'] = '123'
     result = subprocess.run(
         [sys.executable, SCRIPT],
-        input='cd dream\nls\ncd neon_hall_0\nls\nquit\n',
+        input=(
+            'cd dream\nls\ncd neon_hall_0\nls\ncd ..\ncd ..\n'
+            'cd memory\nls\ncd ..\ncd core\nls\nquit\n'
+        ),
         text=True,
         capture_output=True,
         env=env,
@@ -19,4 +22,8 @@ def test_extra_dirs_with_seed():
     assert 'neon_hall_0/' in out
     assert 'echoing_alcove_1/' in out
     assert 'dream0.shard' in out
+    assert 'vivid_alcove_0/' in out
+    assert 'vivid_hall_1/' in out
+    assert 'misty_hall_0/' in out
+    assert 'vivid_hall_2/' in out
     assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- allow `_generate_extra_dirs` to take a list of directories
- generate extra rooms in `dream/`, `memory/` and `core/`
- update deterministic extra dirs test for new locations
- document the feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d5de91c4832aa286e4e402a29333