### PR TITLE
Add decode command and escape code feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ unexpected ways.
    - `ls` – list directories and items in the current location
    - `cd <dir>` – move between directories/rooms
    - `cat <file>` – read narrative logs from `data/`
+   - `decode mem.fragment` – combine the decoder with the memory fragment to reveal an escape code
    - `talk <npc>` – initiate conversation and choose numbered replies
   - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
   - `glitch` – toggle glitch mode for scrambled descriptions. The longer it
@@ -43,6 +44,7 @@ unexpected ways.
   - `decoder` – located in the `lab/` directory
   - `old.note` – stashed away in the `archive/` directory
   - `daemon.log` – consult the system daemon when read or used, found in `core/npc/`
+  - `escape.code` – the deciphered sequence unlocked within the vault
 
    **Rooms**
    - `lab/` – a cluttered research area humming with equipment

--- a/data/escape.code
+++ b/data/escape.code
@@ -1,0 +1,1 @@
+The exit sequence is 042. Use it wisely.

--- a/escape.py
+++ b/escape.py
@@ -92,6 +92,7 @@ class Game:
             "flashback.log": "A recorded memory playback waiting to be relived.",
             "reverie.log": "A log capturing fleeting reveries within the system.",
             "escape.plan": "A hastily sketched route promising a way out.",
+            "escape.code": "A brief sequence hinting at a path to freedom.",
         }
         # populate multiple directories with extra procedurally generated content
         self._generate_extra_dirs(["dream", "memory", "core"])
@@ -125,6 +126,7 @@ class Game:
             "examine": lambda arg="": self._examine(arg),
             "use": lambda arg="": self._use_command(arg),
             "cat": lambda arg="": self._cat(arg),
+            "decode": lambda arg="": self._decode(arg),
             "talk": lambda arg="": self._talk(arg),
             "save": lambda arg="": self._save(arg),
             "load": lambda arg="": self._load(arg),
@@ -288,7 +290,7 @@ class Game:
                 self._output(msg)
             return
         if item == "decoder" and target == "mem.fragment":
-            self._output("The decoder reveals a secret exit command within the fragment.")
+            self._decode("mem.fragment")
             return
         if target:
             self._output(f"You try to use {item} on {target} but nothing happens.")
@@ -312,6 +314,29 @@ class Game:
             target = None
         if item:
             self._use(item, target)
+
+    def _decode(self, item: str) -> None:
+        target = item.strip()
+        if target != "mem.fragment":
+            self._output(f"Don't know how to decode {target}.")
+            return
+        if "decoder" not in self.inventory:
+            self._output("You need the decoder to decode the fragment.")
+            return
+        if target not in self.inventory:
+            self._output(f"You do not have {target} to decode.")
+            return
+        self.inventory.remove(target)
+        vault = self.hidden_dir["dirs"]["vault"]
+        if "escape" not in vault["dirs"]:
+            vault["dirs"]["escape"] = {
+                "desc": "A compartment revealed by decoding the fragment.",
+                "items": ["escape.code"],
+                "dirs": {},
+            }
+        self._output(
+            "The decoder hums and a new directory appears within hidden/vault."
+        )
 
     def _cat(self, filename: str):
         path = self.data_dir / filename

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -464,6 +464,32 @@ def test_hidden_vault_and_escape_plan():
     assert 'Goodbye' in out
 
 
+def test_decode_fragment_unlocks_escape_directory():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'take access.key\n'
+            'use access.key\n'
+            'cd hidden\n'
+            'take mem.fragment\n'
+            'cd ..\n'
+            'cd lab\n'
+            'take decoder\n'
+            'decode mem.fragment\n'
+            'cd ..\n'
+            'cd hidden\n'
+            'cd vault\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'escape/' in out
+    assert 'Goodbye' in out
+
+
 def test_save_slots_independent(tmp_path):
     save1 = tmp_path / 'game1.sav'
     save2 = tmp_path / 'game2.sav'


### PR DESCRIPTION
## Summary
- add `decode` command to the command registry
- implement `_decode` method that consumes `mem.fragment` with the decoder and unlocks `/hidden/vault/escape`
- include new narrative file `escape.code`
- describe the feature in `README`
- test decoding flow from unlocking hidden vault to revealing the new directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d706f740832a8e0603f197ea9751