### PR TITLE
Add branching dialog options

### DIFF
--- a/data/npc/daemon.dialog
+++ b/data/npc/daemon.dialog
@@ -1,3 +1,8 @@
 The daemon acknowledges your presence.
+> Ask about system status
+> Ask about hidden directories
 "Keep your code clean," it drones.
 "Perhaps there is more to learn from the fragments."
+> Request a hint
+> Leave the daemon
+"Decoding the fragment might reveal an escape path," it whispers.

--- a/data/npc/dreamer.dialog
+++ b/data/npc/dreamer.dialog
@@ -1,3 +1,9 @@
 The dreamer watches you closely.
 > Ask about escape
 > Ask about dreams
+> Ask about the fragment
+The dreamer smiles faintly.
+"The decoder in the lab will reveal what the fragment hides."
+> Thank the dreamer
+> Return to reality
+The dream fades around you.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -403,27 +403,31 @@ def test_glitch_intensity_increases():
 def test_talk_daemon():
     result = subprocess.run(
         [sys.executable, SCRIPT],
-        input='cd core\ncd npc\ntalk daemon\nquit\n',
+        input='cd core\ncd npc\ntalk daemon\n1\n1\nquit\n',
         text=True,
         capture_output=True,
     )
     out = result.stdout
     assert 'acknowledges your presence' in out
-    assert 'more to learn' in out
+    assert '1. Ask about system status' in out
+    assert '1. Request a hint' in out
+    assert 'Decoding the fragment might reveal an escape path' in out
     assert 'Goodbye' in out
 
 
 def test_talk_dreamer():
     result = subprocess.run(
         [sys.executable, SCRIPT],
-        input='cd dream\ncd npc\ntalk dreamer\n1\nquit\n',
+        input='cd dream\ncd npc\ntalk dreamer\n1\n2\nquit\n',
         text=True,
         capture_output=True,
     )
     out = result.stdout
     assert 'dreamer watches you' in out
     assert '1. Ask about escape' in out
+    assert '3. Ask about the fragment' in out
     assert 'Ask about escape' in out
+    assert 'The decoder in the lab will reveal what the fragment hides.' in out
     assert 'Goodbye' in out
 
 


### PR DESCRIPTION
## Summary
- expand Dreamer and Daemon dialog scripts with numbered choices
- show puzzle hints about decoding the fragment
- update tests for new dialog option handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d7dc4d58832a8fdf54d783724af6