### PR TITLE
Add ET_EXTRA_COUNT and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ By default the `dream/`, `memory/` and `core/` directories each receive two or
 three generated locations, sometimes containing unique items. Set the
 `ET_EXTRA_SEED` environment variable before launching to make this generation
 deterministic for reproducible testing or custom scenarios.
+You can also set `ET_EXTRA_COUNT` to control exactly how many extra directories
+are created under each base path.
 
 ## Command Registry
 Commands are routed through the ``Game.command_map`` dictionary. Each command

--- a/escape.py
+++ b/escape.py
@@ -159,6 +159,11 @@ class Game:
 
         seed_val = os.getenv("ET_EXTRA_SEED")
         rnd = random.Random(int(seed_val)) if seed_val is not None else random.Random()
+        count_val = os.getenv("ET_EXTRA_COUNT")
+        try:
+            fixed_count = int(count_val) if count_val is not None else None
+        except ValueError:
+            fixed_count = None
 
         adjectives = ["misty", "vivid", "neon", "echoing"]
         nouns = ["hall", "nexus", "alcove", "node"]
@@ -172,7 +177,7 @@ class Game:
             if not base_node:
                 continue
 
-            count = rnd.randint(2, 3)
+            count = fixed_count if fixed_count is not None else rnd.randint(2, 3)
             for idx in range(count):
                 dname = f"{rnd.choice(adjectives)}_{rnd.choice(nouns)}_{idx}"
                 desc = (

--- a/tests/test_extra_dirs.py
+++ b/tests/test_extra_dirs.py
@@ -27,3 +27,28 @@ def test_extra_dirs_with_seed():
     assert 'misty_hall_0/' in out
     assert 'vivid_hall_2/' in out
     assert 'Goodbye' in out
+
+
+def test_extra_dirs_with_seed_and_count():
+    env = os.environ.copy()
+    env['ET_EXTRA_SEED'] = '123'
+    env['ET_EXTRA_COUNT'] = '2'
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd dream\nls\ncd ..\n'
+            'cd memory\nls\ncd ..\n'
+            'cd core\nls\nquit\n'
+        ),
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    out = result.stdout
+    assert 'misty_alcove_0/' in out
+    assert 'neon_hall_1/' in out
+    assert 'neon_alcove_0/' in out
+    assert 'neon_nexus_1/' in out
+    assert 'misty_node_0/' in out
+    assert 'echoing_hall_1/' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- allow `_generate_extra_dirs` to read `ET_EXTRA_COUNT` for deterministic subdir counts
- document `ET_EXTRA_COUNT`
- test deterministic directory creation when seed and count are set

## Testing
- `pip install -e '.[test]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e3839660832aa188b635d8f182b2