### PR TITLE
Add new NPCs with stateful dialog choices

### DIFF
--- a/data/npc/sysop.dialog
+++ b/data/npc/sysop.dialog
@@ -1,0 +1,13 @@
+The sysop glances over from a console.
+> Greet politely [+polite]
+> Demand access [-polite]
+?polite:The sysop nods at your respect.
+?!polite:The sysop scowls at your tone.
+---
+?polite:The sysop welcomes your return.
+?!polite:The sysop folds their arms warily.
+> Ask about commands
+> Leave
+"Try 'glitch' when things feel unstable."
+---
+The sysop is lost in system readouts.

--- a/data/npc/wanderer.dialog
+++ b/data/npc/wanderer.dialog
@@ -1,0 +1,13 @@
+A weary wanderer drifts through the data fog.
+> Ask about memories
+> Offer help [+helped]
+> Leave
+"Wander while you can, friend."
+---
+?helped:The wanderer smiles and shares a secret path.
+?!helped:The wanderer barely notices you.
+> Seek advice
+> Leave
+"Paths shift with each reboot."
+---
+The wanderer fades into the mist.

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -32,3 +32,32 @@ def test_dreamer_follow_up():
     assert 'Trust the path the fragment reveals' in out
     assert 'Goodbye' in out
 
+
+def test_sysop_polite_branch():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd core\ncd npc\ntalk sysop\n1\ntalk sysop\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'sysop glances over' in out
+    assert 'nods at your respect' in out
+    assert 'welcomes your return' in out
+    assert 'glitch' in out
+    assert 'Goodbye' in out
+
+
+def test_wanderer_helped_branch():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\ncd npc\ntalk wanderer\n2\ntalk wanderer\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'weary wanderer drifts' in out
+    assert 'shares a secret path' in out
+    assert 'Paths shift with each reboot' in out
+    assert 'Goodbye' in out
+


### PR DESCRIPTION
## Summary
- create dialog files for new NPCs `sysop` and `wanderer`
- expand `Game.npc_locations` and track NPC flags
- enhance `_talk` to support flag-setting choices and conditional lines
- test new branching dialog behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e6b03e0c832a8d04b3391df4025b