### PR TITLE
Add network scan and hacking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,4 +197,5 @@ cython_debug/
 !data/flashback.log
 !data/reverie.log
 !data/escape.plan
+!data/node.log
 data/logs/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ unexpected ways.
    - `cat <file>` – read narrative logs from `data/`
    - `decode mem.fragment` – combine the decoder with the memory fragment to reveal an escape code
    - `talk <npc>` – initiate conversation and choose numbered replies
-  - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
+   - `scan <dir>` – search a directory for hidden nodes
+   - `hack <dir>` – attempt to unlock a scanned node
+   - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
   - `glitch` – toggle glitch mode for scrambled descriptions. The longer it
     stays active the stronger the corruption becomes and occasional glitch
     messages may appear.
@@ -48,11 +50,13 @@ unexpected ways.
   - `old.note` – stashed away in the `archive/` directory
   - `daemon.log` – consult the system daemon when read or used, found in `core/npc/`
   - `escape.code` – the deciphered sequence unlocked within the vault
+  - `port.scanner` – enables hacking of network nodes, found in the `lab/`
 
    **Rooms**
    - `lab/` – a cluttered research area humming with equipment
   - `archive/` – dusty shelves of old backups and forgotten notes
   - `core/npc/` – a secluded nook where a daemon awaits interaction
+  - `network/` – a tangle of digital links hiding a locked node
 
 ## Running Tests
 Tests are written with `pytest` and live under the `tests/` directory. After installing

--- a/data/node.log
+++ b/data/node.log
@@ -1,0 +1,1 @@
+Intrusion attempts detected. Security protocols remain intact.

--- a/data/port.scanner
+++ b/data/port.scanner
@@ -1,0 +1,1 @@
+A compact tool that sweeps network ports and reveals hidden entry points.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,40 @@
+import subprocess, sys, os
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'escape.py')
+
+
+def test_scan_reveals_locked_node():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='scan network\ncd network\nls\ncd node\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node' in out
+    assert 'node/' in out
+    assert 'node is locked' in out
+    assert 'Goodbye' in out
+
+
+def test_hack_unlocks_node():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'cd node\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'node.log' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add a `network/` area with a locked `node/`
- provide files `port.scanner` and `node.log`
- add `scan` and `hack` commands
- update README for new commands and items
- include tests for scanning and hacking

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e7ce6e3c832a914ea87c23db4009