### PR TITLE
Improve grep command syntax

### DIFF
--- a/tests/test_logs_grep.py
+++ b/tests/test_logs_grep.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from escape import Game
 
 SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'escape.py')
@@ -23,7 +24,34 @@ def test_grep_finds_boot_message():
         text=True,
         capture_output=True,
     )
+    out = result.stdout.splitlines()
+    boot_lines = [line for line in out if 'SYSTEM BOOT COMPLETE' in line]
+    assert boot_lines, 'boot message not found'
+    prefix = boot_lines[0].split(':')
+    assert prefix[0].endswith('.log')
+    assert prefix[1].isdigit()
+    assert 'SYSTEM BOOT COMPLETE' in boot_lines[0]
+    assert 'Goodbye' in result.stdout
+
+
+def test_grep_specific_file(tmp_path):
+    env = os.environ.copy()
+    env['ET_EXTRA_SEED'] = '123'
+    os.environ['ET_EXTRA_SEED'] = '123'
+    game = Game()
+    target = sorted(game.logs_path.glob('*.log'))[0].name
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=f'grep iteration {target}\nquit\n',
+        text=True,
+        capture_output=True,
+        env=env,
+    )
     out = result.stdout
-    assert 'SYSTEM BOOT COMPLETE' in out
+    assert f'{target}:1:' in out
+    assert 'INFO iteration' in out
+    assert out.count(f'{target}:') == 1
     assert 'Goodbye' in out
+
+    os.environ.pop('ET_EXTRA_SEED', None)
 


### PR DESCRIPTION
## Summary
- update grep command syntax to accept optional filename
- search either one log or all logs and show line numbers
- test updated grep behavior

## Testing
- `pytest tests/test_logs_grep.py::test_log_files_created -q`
- `pytest tests/test_logs_grep.py::test_grep_finds_boot_message -q`
- `pytest tests/test_logs_grep.py::test_grep_specific_file -q`
- `pytest -q` *(fails: test_console_script_invocation)*

------
https://chatgpt.com/codex/tasks/task_e_6854e90bc5ac832aae05bb3107ef1dd7