### PR TITLE
Add dedicated tests for help command, NPC branching and network puzzle

### DIFF
--- a/tests/test_help_all_commands.py
+++ b/tests/test_help_all_commands.py
@@ -1,0 +1,10 @@
+import pytest
+from escape import Game
+
+
+def test_help_for_each_command(capsys):
+    game = Game()
+    for cmd, desc in game.command_descriptions.items():
+        game._print_help(cmd)
+        out = capsys.readouterr().out
+        assert f"{cmd}: {desc}" in out

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -38,3 +38,37 @@ def test_hack_unlocks_node():
     assert 'Access granted' in out
     assert 'node.log' in out
     assert 'Goodbye' in out
+
+
+def test_hack_requires_scanner():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='scan network\nhack network\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the port.scanner to hack this node.' in out
+    assert 'Goodbye' in out
+
+
+def test_cat_node_log_after_hack():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'cd node\n'
+            'cat node.log\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Intrusion attempts detected.' in out
+    assert 'Goodbye' in out

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -61,3 +61,31 @@ def test_wanderer_helped_branch():
     assert 'Paths shift with each reboot' in out
     assert 'Goodbye' in out
 
+
+def test_sysop_rude_branch():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd core\ncd npc\ntalk sysop\n2\ntalk sysop\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'sysop glances over' in out
+    assert 'scowls at your tone' in out
+    assert 'folds their arms warily' in out
+    assert 'glitch' in out
+    assert 'Goodbye' in out
+
+
+def test_wanderer_ignored_branch():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\ncd npc\ntalk wanderer\n1\ntalk wanderer\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'weary wanderer drifts' in out
+    assert 'barely notices you' in out
+    assert 'Paths shift with each reboot' in out
+    assert 'Goodbye' in out

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+import os
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'escape.py')
+
+
+def test_take_drop_after_network_puzzle():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'take access.key\n'
+            'drop access.key\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You pick up the access.key' in out
+    assert 'You drop the access.key' in out
+    assert 'access.key' in out
+    assert 'Goodbye' in out
+
+
+def test_help_then_look():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='help look\nlook\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'look: Describe the current room' in out
+    assert 'dimly lit terminal' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- ensure `help <command>` covers all commands
- add NPC branch tests for rude/wanderer ignoring
- extend network puzzle tests for failure and log reading
- add regression suite for classic commands

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e9dbc8b4832a816b3d25b02b68f4