### PR TITLE
Add nested network nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,4 +198,5 @@ cython_debug/
 !data/reverie.log
 !data/escape.plan
 !data/node.log
+!data/deep.node.log
 data/logs/

--- a/data/auth.token
+++ b/data/auth.token
@@ -1,0 +1,1 @@
+Token granting deeper network privileges.

--- a/data/deep.node.log
+++ b/data/deep.node.log
@@ -1,0 +1,1 @@
+Deep system diagnostics reveal hidden routines.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -72,3 +72,76 @@ def test_cat_node_log_after_hack():
     out = result.stdout
     assert 'Intrusion attempts detected.' in out
     assert 'Goodbye' in out
+
+
+def test_scan_nested_node():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node2' in out
+    assert 'node2/' in out
+
+
+def test_hack_node2_requires_token():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'hack node2\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the auth.token to hack this node.' in out
+
+
+def test_hack_node2_success():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'cd node\n'
+            'take auth.token\n'
+            'cd ..\n'
+            'scan node\n'
+            'cd node\n'
+            'hack node2\n'
+            'cd node2\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'deep.node.log' in out


### PR DESCRIPTION
## Summary
- support multiple nested network nodes
- add auth token and deep node log items
- describe new files in the game data
- extend scan/hack to reveal and unlock deeper nodes
- test deeper network discovery and hacking logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ee893ca0832aa60cfe7f3628dbc3