### PR TITLE
Add oracle NPC with dialog and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ unexpected ways.
   - `archive/` – dusty shelves of old backups and forgotten notes
   - `core/npc/` – a secluded nook where a daemon awaits interaction
   - `network/` – a tangle of digital links hiding a locked node
+  - `dream/oracle/` – an enigmatic hall where the oracle offers cryptic advice
 
 ## Running Tests
 Tests are written with `pytest` and live under the `tests/` directory. After installing
@@ -99,3 +100,5 @@ The dreamer watches you closely.
 
 Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.
+The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
+NPC located under ``dream/oracle/``.

--- a/data/npc/oracle.dialog
+++ b/data/npc/oracle.dialog
@@ -1,0 +1,11 @@
+The oracle hovers in a loop of swirling code.
+> Seek prophecy
+> Walk away
+"The fragment only reveals its meaning in dreams."
+---
+The oracle watches your every move.
+> Ask again
+> Leave
+"Decode the echoes of your past to open the gate."
+---
+The oracle fades into static.

--- a/escape.py
+++ b/escape.py
@@ -84,6 +84,11 @@ class Game:
                             "items": [],
                             "dirs": {},
                         },
+                        "oracle": {
+                            "desc": "An enigmatic chamber humming with distant voices.",
+                            "items": [],
+                            "dirs": {},
+                        },
                     },
                 },
                 "memory": {
@@ -104,6 +109,7 @@ class Game:
             "dreamer": ["dream", "npc"],
             "sysop": ["core", "npc"],
             "wanderer": ["dream", "npc"],
+            "oracle": ["dream", "oracle"],
         }
         # track dialogue progress and flags for each NPC
         self.npc_state: dict[str, dict] = {}

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -89,3 +89,17 @@ def test_wanderer_ignored_branch():
     assert 'barely notices you' in out
     assert 'Paths shift with each reboot' in out
     assert 'Goodbye' in out
+
+
+def test_oracle_follow_up():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input='cd dream\ncd oracle\ntalk oracle\n1\n1\ntalk oracle\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'oracle hovers in a loop' in out
+    assert 'watches your every move' in out
+    assert 'Decode the echoes of your past' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- introduce `oracle.dialog` with multi-stage conversation
- add oracle location under `dream/` and map it in `npc_locations`
- extend test suite for talking to the oracle
- document new NPC and directory in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f171413c832ab4ebfd3afb65e40e