### PR TITLE
Add plugin loading system

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.
 The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
 NPC located under ``dream/oracle/``.
+
+## Plugins
+Python files placed in ``escape/plugins/`` are imported automatically when a
+``Game`` instance is created. Each module receives the active ``game`` object
+via a global variable and may register new commands by updating
+``game.command_map`` during import.


### PR DESCRIPTION
## Summary
- allow `Game` to load plugins from `escape/plugins/`
- implement `_load_plugins` method
- document plugin support in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f7c8d8a0832a9b36ad2e8de8dbe0