### PR TITLE
Add autosave via ET_AUTOSAVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ deterministic for reproducible testing or custom scenarios.
 You can also set `ET_EXTRA_COUNT` to control exactly how many extra directories
 are created under each base path.
 
+## Autosave
+Set the `ET_AUTOSAVE` environment variable to automatically write `game.sav`
+after every successful command. This is handy for continuous progress backups or
+automated testing.
+
 ## Command Registry
 Commands are routed through the ``Game.command_map`` dictionary. Each command
 string or alias maps to a handler method. When adding a new command simply

--- a/escape/game.py
+++ b/escape/game.py
@@ -17,6 +17,8 @@ class Game:
             self.use_color = env_val not in ("0", "false", "")
         else:
             self.use_color = use_color
+
+        self.auto_save = os.getenv("ET_AUTOSAVE") not in (None, "", "0", "false")
         self.inventory = []
         # base filesystem state; the hidden directory is injected when unlocked
         self.hidden_dir = {
@@ -904,5 +906,7 @@ class Game:
                 should_quit = handler(arg)
                 if should_quit:
                     break
+                if self.auto_save:
+                    self._save()
             else:
                 self._output(f"Unknown command: {cmd}")

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_autosave_creates_file(tmp_path):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    env['ET_AUTOSAVE'] = '1'
+    subprocess.run(
+        CMD,
+        input='look\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert (tmp_path / 'game.sav').exists()
+
+
+def test_autosave_saves_state(tmp_path):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    env['ET_AUTOSAVE'] = '1'
+    subprocess.run(
+        CMD,
+        input='take access.key\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert (tmp_path / 'game.sav').exists()
+
+    result = subprocess.run(
+        CMD,
+        input='load\ninventory\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert 'Inventory: access.key' in result.stdout
+


### PR DESCRIPTION
## Summary
- add `ET_AUTOSAVE` env var and hook autosave into the command loop
- document the autosave behaviour in the README
- test autosave creates `game.sav` and persists state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f9de0638832abdadd82092080ab6