### PR TITLE
Add dance plugin with command registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
 NPC located under ``dream/oracle/``.
 
 ## Plugins
-Python files placed in ``escape/plugins/`` are imported automatically when a
-``Game`` instance is created. Each module receives the active ``game`` object
-via a global variable and may register new commands by updating
-``game.command_map`` during import.
+Python files placed in ``escape/plugins/`` are discovered on startup. The game
+scans this directory for ``*.py`` modules (ignoring names beginning with
+``__``) and imports each one. Every plugin module receives the active ``game``
+object via a global variable and can register new commands by updating
+``game.command_map`` during import. The included ``dance.py`` plugin adds a
+simple ``dance`` command as an example.

--- a/escape/plugins/dance.py
+++ b/escape/plugins/dance.py
@@ -1,0 +1,7 @@
+def dance(arg=""):
+    """Print a playful dance message."""
+    game._output(f"Dancing {arg}" if arg else "Dancing")
+
+# register the command on import
+if 'game' in globals():
+    game.command_map['dance'] = lambda arg="": dance(arg)


### PR DESCRIPTION
## Summary
- add a small `dance` plugin
- document plugin discovery process and the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fc31362c832ab9878d745300cb62