### PR TITLE
Add oracle vision stage

### DIFF
--- a/escape/data/npc/oracle.dialog
+++ b/escape/data/npc/oracle.dialog
@@ -1,11 +1,17 @@
 The oracle hovers in a loop of swirling code.
-> Seek prophecy
-> Walk away
+> Seek prophecy [+vision]
+> Walk away [-vision]
 "The fragment only reveals its meaning in dreams."
 ---
 The oracle watches your every move.
 > Ask again
 > Leave
 "Decode the echoes of your past to open the gate."
+---
+?vision:The oracle unveils a vision of hidden paths.
+?!vision:The oracle's messages remain cryptic.
+> Contemplate the vision
+> Step away
+"The images swirl before dissolving into noise."
 ---
 The oracle fades into static.

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -95,7 +95,7 @@ def test_wanderer_ignored_branch():
 def test_oracle_follow_up():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd oracle\ntalk oracle\n1\n1\ntalk oracle\n1\nquit\n',
+        input='cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\nquit\n',
         text=True,
         capture_output=True,
     )
@@ -103,4 +103,19 @@ def test_oracle_follow_up():
     assert 'oracle hovers in a loop' in out
     assert 'watches your every move' in out
     assert 'Decode the echoes of your past' in out
+    assert 'Goodbye' in out
+
+
+def test_oracle_vision_stage():
+    result = subprocess.run(
+        CMD,
+        input='cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\ntalk oracle\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'oracle hovers in a loop' in out
+    assert 'watches your every move' in out
+    assert 'unveils a vision of hidden paths' in out
+    assert 'images swirl before dissolving into noise' in out
     assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add a flag-based vision stage to `oracle.dialog`
- adjust Oracle dialog test to match interaction
- add new test validating vision stage progression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fd7e196c832ab70093fbc3c1a651