### PR TITLE
Add sleep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ unexpected ways.
     stays active the stronger the corruption becomes and occasional glitch
     messages may appear.
   - `history` – display the commands you've entered this session
+  - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
+    clear glitches or `inc` to deepen them
 
    **Core files/items**
   - `access.key` – unlocks the hidden directory when used on the door

--- a/escape/game.py
+++ b/escape/game.py
@@ -182,6 +182,7 @@ class Game:
             "load": "Load a saved game",
             "glitch": "Toggle glitch mode",
             "history": "Show command history",
+            "sleep": "Enter the dream state and rest",
             "restart": "Restart the game",
             "quit": "Exit the game",
             "alias": "Create command shortcuts",
@@ -214,6 +215,7 @@ class Game:
             "load": lambda arg="": self._load(arg),
             "glitch": lambda arg="": self._toggle_glitch(),
             "history": lambda arg="": self._history(),
+            "sleep": lambda arg="": self._sleep(arg),
             "restart": lambda arg="": self._restart(),
             "quit": lambda arg="": self._quit(),
             "exit": lambda arg="": self._quit(),
@@ -867,6 +869,19 @@ class Game:
         name, target = parts[0].lower(), parts[1].lower()
         self.aliases[name] = target
         self._output(f"Alias {name} -> {target}")
+
+    def _sleep(self, arg: str = "") -> None:
+        """Enter the dream directory and optionally modify glitch intensity."""
+        arg = arg.strip().lower()
+        if not self.current or self.current[0] != "dream":
+            self.current = ["dream"]
+            self._output("You drift into a dream.")
+        else:
+            self._output("You are already dreaming.")
+        if arg == "reset":
+            self.glitch_steps = 0
+        elif arg in ("inc", "increase", "++"):
+            self.glitch_steps += 1
 
     def _restart(self) -> None:
         """Reset game state while preserving color settings."""

--- a/tests/test_sleep_command.py
+++ b/tests/test_sleep_command.py
@@ -1,0 +1,21 @@
+from escape import Game
+
+
+def test_sleep_moves_to_dream(capsys):
+    game = Game()
+    game._sleep()
+    capsys.readouterr()
+    assert game.current == ['dream']
+
+
+def test_sleep_resets_glitch():
+    game = Game()
+    game.glitch_steps = 5
+    game._sleep('reset')
+    assert game.glitch_steps == 0
+
+
+def test_sleep_increments_glitch():
+    game = Game()
+    game._sleep('inc')
+    assert game.glitch_steps == 1


### PR DESCRIPTION
## Summary
- add `Game._sleep()` handler
- expose `sleep` via command map and help text
- document sleep feature in README
- test entering dream and glitch step changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fe72909c832aaae5f9b3d89124cf