### PR TITLE
Add custom world CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,5 @@ simple ``dance`` command as an example.
 The starting filesystem, NPC locations and item descriptions are defined in
 ``escape/data/world.json``. Modify this file to reshape the world or provide a
 completely new JSON file when instantiating ``Game`` using the ``world_file``
-parameter.
+parameter. When running the CLI you can pass ``--world <file>`` to load an
+alternate JSON world.

--- a/escape/cli.py
+++ b/escape/cli.py
@@ -6,8 +6,9 @@ def main(argv: list[str] | None = None):
 
     parser = argparse.ArgumentParser(description="Escape the Terminal")
     parser.add_argument("--color", action="store_true", help="enable ANSI colors")
+    parser.add_argument("--world", metavar="file", help="path to custom world JSON")
     args = parser.parse_args(argv)
 
     game_color = True if args.color else None
-    Game(use_color=game_color).run()
+    Game(use_color=game_color, world_file=args.world).run()
 

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -17,3 +17,36 @@ def test_console_script_invocation():
     )
     assert 'Goodbye' in result.stdout
     assert result.returncode == 0
+
+
+def test_world_option(tmp_path):
+    import json
+    import os
+
+    world = tmp_path / 'world.json'
+    world.write_text(
+        json.dumps(
+            {
+                'fs': {'desc': 'Custom root', 'items': [], 'dirs': {}},
+                'hidden_dir': {'desc': '', 'items': [], 'dirs': {}},
+                'network_node': {'desc': '', 'items': [], 'dirs': {}, 'locked': False},
+                'deep_network_node': {'desc': '', 'items': [], 'dirs': {}, 'locked': False},
+                'npc_locations': {},
+                'item_descriptions': {},
+            }
+        )
+    )
+
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.path.dirname(os.path.dirname(__file__))
+    result = subprocess.run(
+        [sys.executable, '-m', 'escape', '--world', str(world)],
+        input='look\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    out = result.stdout
+    assert 'Custom root' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add `--world` flag to command line interface
- mention how to use it in the README
- test that the option works by passing a minimal world file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855022a4924832a9317724e42b2bdf7