### PR TITLE
Implement unalias command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ unexpected ways.
   - `history` – display the commands you've entered this session
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them
+  - `alias <name> <command>` – create a custom shortcut
+  - `unalias <name>` – remove a previously defined shortcut
 
-   **Core files/items**
+  **Core files/items**
   - `access.key` – unlocks the hidden directory when used on the door
    - `voice.log` – whispers a clue when read
    - `mem.fragment` – a corrupted memory chunk found in `hidden/`

--- a/escape/game.py
+++ b/escape/game.py
@@ -86,6 +86,7 @@ class Game:
             "restart": "Restart the game",
             "quit": "Exit the game",
             "alias": "Create command shortcuts",
+            "unalias": "Remove a command alias",
         }
 
         # map commands and aliases to handler callables
@@ -120,6 +121,7 @@ class Game:
             "quit": lambda arg="": self._quit(),
             "exit": lambda arg="": self._quit(),
             "alias": lambda arg="": self._alias(arg),
+            "unalias": lambda arg="": self._unalias(arg),
         }
 
         # discover and load optional plugin modules
@@ -322,7 +324,8 @@ class Game:
             return
         self._output(
             "Available commands: help, look, ls, cd <dir>, pwd, take <item>, drop <item>, "
-            "inventory, examine <item>, use <item> [on <target>], cat <file>, talk <npc>, save [slot], load [slot], glitch, quit"
+            "inventory, examine <item>, use <item> [on <target>], cat <file>, talk <npc>, "
+            "save [slot], load [slot], glitch, alias <name> <cmd>, unalias <name>, quit"
         )
 
     def _current_node(self):
@@ -769,6 +772,18 @@ class Game:
         name, target = parts[0].lower(), parts[1].lower()
         self.aliases[name] = target
         self._output(f"Alias {name} -> {target}")
+
+    def _unalias(self, name: str) -> None:
+        """Remove an alias created with :meth:`_alias`."""
+        name = name.strip().lower()
+        if not name:
+            self._output("Usage: unalias <name>")
+            return
+        if name in self.aliases:
+            del self.aliases[name]
+            self._output(f"Removed alias {name}")
+        else:
+            self._output(f"No such alias: {name}")
 
     def _sleep(self, arg: str = "") -> None:
         """Enter the dream directory and optionally modify glitch intensity."""

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -114,3 +114,33 @@ def test_alias_with_args(monkeypatch, capsys):
     assert 'pick up the access.key' in out
     assert 'Inventory: access.key' in out
     assert 'Goodbye' in out
+
+
+def test_unalias_command(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'alias ll look',
+        'unalias ll',
+        'll',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out = capsys.readouterr().out
+    assert 'Alias ll -> look' in out
+    assert 'Removed alias ll' in out
+    assert 'Unknown command: ll' in out
+    assert 'Goodbye' in out
+
+
+def test_unalias_missing(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'unalias nope',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out = capsys.readouterr().out
+    assert 'No such alias: nope' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- allow removing runtime command aliases
- hook new `unalias` command into command map
- document alias and unalias in README
- test alias creation and removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855036fbb08832abda1a9efe06fb683