### PR TITLE
Improve plugin docs and tests

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -32,3 +32,13 @@ def test_temp_plugin_command(monkeypatch, capsys):
     finally:
         plugin_path.unlink(missing_ok=True)
         sys.modules.pop('escape.plugins.temp_plugin', None)
+
+
+def test_dance_plugin_loaded(monkeypatch, capsys):
+    game = Game()
+    inputs = iter(['dance happily', 'quit'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out = capsys.readouterr().out
+    assert 'Dancing happily' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- detail how plugin modules are loaded in README
- highlight the `game` object with a `dance.py` example
- warn about arbitrary code execution
- test that the default `dance` plugin loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550431c440832a8fe1300feffc3f7a