### PR TITLE
Add color command with toggle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ unexpected ways.
    - `talk <npc>` – initiate conversation and choose numbered replies
    - `scan <dir>` – search a directory for hidden nodes
    - `hack <dir>` – attempt to unlock a scanned node
-   - `grep <pattern> [file]` – search log files for matching text
-   - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
+  - `grep <pattern> [file]` – search log files for matching text
+  - `save [slot]` / `load [slot]` – write and restore progress. Without a slot the file `game.sav` is used, otherwise `game<slot>.sav`.
   - `glitch` – toggle glitch mode for scrambled descriptions. The longer it
     stays active the stronger the corruption becomes and occasional glitch
     messages may appear.
+  - `color on` / `color off` / `color toggle` – enable, disable or toggle ANSI colors
   - `history` – display the commands you've entered this session
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them

--- a/escape/game.py
+++ b/escape/game.py
@@ -81,6 +81,7 @@ class Game:
             "save": "Save game state",
             "load": "Load a saved game",
             "glitch": "Toggle glitch mode",
+            "color": "Toggle ANSI color output",
             "history": "Show command history",
             "sleep": "Enter the dream state and rest",
             "restart": "Restart the game",
@@ -115,6 +116,7 @@ class Game:
             "save": lambda arg="": self._save(arg),
             "load": lambda arg="": self._load(arg),
             "glitch": lambda arg="": self._toggle_glitch(),
+            "color": lambda arg="": self._color(arg),
             "history": lambda arg="": self._history(),
             "sleep": lambda arg="": self._sleep(arg),
             "restart": lambda arg="": self._restart(),
@@ -229,6 +231,21 @@ class Game:
             self.glitch_steps = 0
         print(f"Glitch mode {state}.")
 
+    def _color(self, arg: str = "") -> None:
+        """Enable, disable, or toggle ANSI color output."""
+        arg = arg.strip().lower()
+        if not arg or arg == "toggle":
+            self.use_color = not self.use_color
+        elif arg == "on":
+            self.use_color = True
+        elif arg == "off":
+            self.use_color = False
+        else:
+            self._output("Usage: color [on|off|toggle]")
+            return
+        state = "enabled" if self.use_color else "disabled"
+        self._output(f"Color {state}.")
+
     def _output(self, text: str = "") -> None:
         """Print text, applying glitch effects when enabled."""
         if self.glitch_mode and text:
@@ -325,7 +342,7 @@ class Game:
         self._output(
             "Available commands: help, look, ls, cd <dir>, pwd, take <item>, drop <item>, "
             "inventory, examine <item>, use <item> [on <target>], cat <file>, talk <npc>, "
-            "save [slot], load [slot], glitch, alias <name> <cmd>, unalias <name>, quit"
+            "save [slot], load [slot], color [on|off|toggle], glitch, alias <name> <cmd>, unalias <name>, quit"
         )
 
     def _current_node(self):

--- a/tests/test_color_output.py
+++ b/tests/test_color_output.py
@@ -31,3 +31,39 @@ def test_color_flag():
     assert '\x1b[33m' in out
     assert '\x1b[36m' in out
     assert 'Goodbye' in out
+
+
+def test_color_command_on_off():
+    result = subprocess.run(
+        CMD,
+        input='color on\nls\ncolor off\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    lines = result.stdout.splitlines()
+    idx1 = next(i for i, line in enumerate(lines) if 'Color enabled.' in line)
+    first_ls = lines[idx1 + 1]
+    idx2 = next(i for i, line in enumerate(lines) if 'Color disabled.' in line)
+    second_ls = lines[idx2 + 1]
+    assert '\x1b[33m' in first_ls
+    assert '\x1b[36m' in first_ls
+    assert '\x1b[33m' not in second_ls
+    assert '\x1b[36m' not in second_ls
+    assert 'Goodbye' in lines[-1]
+
+
+def test_color_command_toggle():
+    result = subprocess.run(
+        CMD,
+        input='color toggle\nls\ncolor toggle\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    lines = result.stdout.splitlines()
+    idx1 = next(i for i, line in enumerate(lines) if 'Color enabled.' in line)
+    first_ls = lines[idx1 + 1]
+    idx2 = next(i for i, line in enumerate(lines) if 'Color disabled.' in line)
+    second_ls = lines[idx2 + 1]
+    assert '\x1b[33m' in first_ls
+    assert '\x1b[33m' not in second_ls
+    assert 'Goodbye' in lines[-1]


### PR DESCRIPTION
## Summary
- implement `_color` command to enable, disable or toggle ANSI colors
- register the command and update help text
- document color command usage in README
- test color toggling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685504f9c8d4832aae2476c20400a908