### PR TITLE
Add NPC dialog documentation and validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ The dreamer watches you closely.
 > Ask about dreams
 ```
 
+See [docs/NPC_DIALOG.md](docs/NPC_DIALOG.md) for the full file format. The helper
+script `python -m escape.utils.validate_dialog <path>` checks dialog files for
+common mistakes.
+
 Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.
 The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle

--- a/docs/NPC_DIALOG.md
+++ b/docs/NPC_DIALOG.md
@@ -1,0 +1,48 @@
+# NPC Dialog Files
+
+The `.dialog` format drives conversations with NPCs. Each file is processed line by line and may be split into multiple **sections** separated by a line containing only `---`. Talking to an NPC advances to the next section on each interaction while keeping any flags that were set previously.
+
+## Choices
+Lines beginning with `>` are presented to the player as numbered options. The selected text is echoed back and may set a flag:
+
+```
+> Ask about escape [+curious]
+> Demand access [-polite]
+> Pick a style [style=quiet]
+```
+
+- `+flag` sets `flag` to `true`.
+- `-flag` sets `flag` to `false`.
+- `flag` without a prefix also sets the flag to `true`.
+- `flag=value` stores an arbitrary value.
+
+## Conditional lines
+Lines starting with `?` show text only when a flag condition is met. Prefix the flag with `!` to invert the check.
+
+```
+?curious:The NPC nods at your enthusiasm.
+?!curious:The NPC looks skeptical.
+```
+
+## Sections
+Use `---` to divide the dialog into sections. On the first conversation the first section is displayed. Subsequent talks continue with the next section until the end of the file is reached.
+
+## Registering NPCs
+Each NPC name must be mapped to its directory within `Game.npc_locations`. For example:
+
+```python
+from escape import Game
+
+Game.npc_locations['merchant'] = ['market', 'npc']
+```
+
+This places a new `merchant.dialog` under `data/npc/` and associates it with the `market/npc/` location.
+
+## Validator script
+A small helper lives at `escape/utils/validate_dialog.py` to check dialog files for common mistakes. Run it with Python and pass one or more files or directories:
+
+```bash
+python -m escape.utils.validate_dialog escape/data/npc
+```
+
+The script reports missing `:` in conditional lines and unclosed `[]` markers in choices. It exits with a non-zero status when any problems are found.

--- a/escape/utils/validate_dialog.py
+++ b/escape/utils/validate_dialog.py
@@ -1,0 +1,74 @@
+"""Utility to validate NPC dialog files."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _dialog_files(arg: str) -> list[Path]:
+    p = Path(arg)
+    if p.is_dir():
+        return list(p.glob("*.dialog"))
+    return [p]
+
+
+def _check_file(path: Path) -> int:
+    errors = 0
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as e:
+        print(f"{path}: {e}", file=sys.stderr)
+        return 1
+
+    sections = [[]]
+    for line in lines:
+        if line.strip() == "---":
+            sections.append([])
+            continue
+        sections[-1].append(line)
+
+    if not any(sections):
+        print(f"{path}: file is empty", file=sys.stderr)
+        errors += 1
+
+    for s_idx, section in enumerate(sections, 1):
+        for l_idx, line in enumerate(section, 1):
+            stripped = line.lstrip()
+            if stripped.startswith(">"):
+                choice = stripped[1:].strip()
+                if "[" in choice and not choice.endswith("]"):
+                    print(
+                        f"{path}:{s_idx}:{l_idx}: choice missing closing ']'",
+                        file=sys.stderr,
+                    )
+                    errors += 1
+            elif stripped.startswith("?"):
+                if ":" not in stripped[1:]:
+                    print(
+                        f"{path}:{s_idx}:{l_idx}: conditional missing ':'",
+                        file=sys.stderr,
+                    )
+                    errors += 1
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check .dialog files for common mistakes"
+    )
+    parser.add_argument("paths", nargs="+", help="dialog files or directories")
+    args = parser.parse_args(argv)
+
+    total = 0
+    for arg in args.paths:
+        for path in _dialog_files(arg):
+            total += _check_file(path)
+
+    if total:
+        print(f"{total} issue(s) found.", file=sys.stderr)
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document `.dialog` file structure and NPC registration
- add validator script for dialog files
- link to documentation and validator from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685506b18cac832a894002186bb505d7