### PR TITLE
Add __future__ annotations for Python 3.8 compatibility

### DIFF
--- a/escape/cli.py
+++ b/escape/cli.py
@@ -1,3 +1,6 @@
+
+from __future__ import annotations
+
 from .game import Game
 
 

--- a/escape/game.py
+++ b/escape/game.py
@@ -4,6 +4,8 @@ This module now exposes a :class:`Game` object to make future expansion
 easier while preserving the original command-line interface.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 import os
 import json


### PR DESCRIPTION
## Summary
- support Python 3.8 by deferring evaluation of type hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685509386cd4832a9a2d59ed1bc01fb3