### PR TITLE
Fix alias persistence in game saves

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -731,6 +731,7 @@ class Game:
             "glitch_mode": self.glitch_mode,
             "glitch_steps": self.glitch_steps,
             "npc_state": self.npc_state,
+            "aliases": self.aliases,
         }
         try:
             with open(fname, "w", encoding="utf-8") as f:
@@ -762,6 +763,7 @@ class Game:
         self.glitch_mode = data.get("glitch_mode", False)
         self.glitch_steps = data.get("glitch_steps", 0)
         self.npc_state = data.get("npc_state", {})
+        self.aliases = data.get("aliases", {})
         self._output("Game loaded.")
 
     def _history(self) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -664,3 +664,28 @@ def test_history_command():
     assert '> look\ninventory\nhistory' in out
     assert 'Goodbye' in result.stdout
 
+
+def test_alias_persists_after_save_load(tmp_path):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    subprocess.run(
+        CMD,
+        input='alias ll look\nsave\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+
+    result = subprocess.run(
+        CMD,
+        input='load\nll\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    out = result.stdout
+    assert 'dimly lit terminal' in out
+    assert 'Unknown command: ll' not in out
+


### PR DESCRIPTION
## Summary
- persist runtime aliases when saving a game
- restore aliases from save data on load
- test alias functionality after saving and loading

## Testing
- `pytest -q tests/test_basic.py::test_alias_persists_after_save_load`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550b5dc688832a821517037e0774e6