### PR TITLE
Add ET_PLUGIN_PATH support

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,13 +7,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from escape import Game
 
 
-def test_temp_plugin_command(monkeypatch, capsys):
-    plugin_path = (
-        Path(__file__).resolve().parent.parent
-        / 'escape'
-        / 'plugins'
-        / 'temp_plugin.py'
-    )
+def test_temp_plugin_command(monkeypatch, capsys, tmp_path):
+    plugin_dir = tmp_path / 'plugins'
+    plugin_dir.mkdir()
+    plugin_path = plugin_dir / 'temp_plugin.py'
     plugin_code = (
         "def hello(arg=\"\"):\n"
         "    game._output(\"Hello from plugin\")\n\n"
@@ -21,6 +18,7 @@ def test_temp_plugin_command(monkeypatch, capsys):
         "    game.command_map['hello'] = lambda arg=\"\": hello(arg)\n"
     )
     plugin_path.write_text(plugin_code)
+    monkeypatch.setenv('ET_PLUGIN_PATH', str(plugin_dir))
     try:
         game = Game()
         inputs = iter(['hello', 'quit'])
@@ -31,7 +29,8 @@ def test_temp_plugin_command(monkeypatch, capsys):
         assert 'Goodbye' in out
     finally:
         plugin_path.unlink(missing_ok=True)
-        sys.modules.pop('escape.plugins.temp_plugin', None)
+        monkeypatch.delenv('ET_PLUGIN_PATH', raising=False)
+        sys.modules.pop('temp_plugin', None)
 
 
 def test_dance_plugin_loaded(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- allow loading plugins from directories specified in ET_PLUGIN_PATH
- test plugin discovery using a custom path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550ccecffc832a9a09e7f771217bb8