### PR TITLE
Add configurable prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Set the `ET_AUTOSAVE` environment variable to automatically write `game.sav`
 after every successful command. This is handy for continuous progress backups or
 automated testing.
 
+## Custom Prompt
+Set the `ET_PROMPT` environment variable to change the input prompt shown to
+the player. The default prompt is `> `.
+
 ## Command Registry
 Commands are routed through the ``Game.command_map`` dictionary. Each command
 string or alias maps to a handler method. When adding a new command simply

--- a/escape/game.py
+++ b/escape/game.py
@@ -14,7 +14,12 @@ import json
 class Game:
     """Simple command dispatcher for the terminal adventure."""
 
-    def __init__(self, use_color: bool | None = None, world_file: str | Path | None = None):
+    def __init__(
+        self,
+        use_color: bool | None = None,
+        world_file: str | Path | None = None,
+        prompt: str | None = None,
+    ):
         if use_color is None:
             env_val = os.getenv("ET_COLOR", "0").lower()
             self.use_color = env_val not in ("0", "false", "")
@@ -22,6 +27,7 @@ class Game:
             self.use_color = use_color
 
         self.auto_save = os.getenv("ET_AUTOSAVE") not in (None, "", "0", "false")
+        self.prompt = prompt if prompt is not None else os.getenv("ET_PROMPT", "> ")
         self.inventory = []
         self.data_dir = Path(__file__).parent / "data"
         if world_file is None:
@@ -849,7 +855,7 @@ class Game:
         self._output("Type 'help' for a list of commands. Type 'quit' to exit.")
         while True:
             try:
-                raw = input('> ')
+                raw = input(self.prompt)
                 cmd = raw.strip()
                 self.command_history.append(cmd)
                 cmd = cmd.lower()

--- a/tests/test_prompt_env.py
+++ b/tests/test_prompt_env.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_prompt_env_variable():
+    env = os.environ.copy()
+    env['ET_PROMPT'] = '>>> '
+    result = subprocess.run(
+        CMD,
+        input='quit\n',
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert '>>> Goodbye' in result.stdout


### PR DESCRIPTION
## Summary
- allow `Game` prompt customization via ET_PROMPT env var
- mention new environment variable in README
- test prompt customization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550d721a44832aac28af9e91767037