### PR TITLE
Add Node4 hacking with root access item

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -103,7 +103,11 @@
     "items": [
       "deep.node.log"
     ],
-    "dirs": {},
+    "dirs": {
+      "node4": {
+        "desc": "The deepest node rumored to grant root access."
+      }
+    },
     "locked": true
   },
   "npc_locations": {
@@ -145,6 +149,7 @@
     "node.log": "Logs from a secure network node.",
     "auth.token": "A multi-factor token used for deeper authentication.",
     "deep.node.log": "Diagnostics from the heart of the network.",
-    "firmware.patch": "A subtle exploit enabling access to even deeper nodes."
+    "firmware.patch": "A subtle exploit enabling access to even deeper nodes.",
+    "root.access": "Credentials granting unrestricted control over the system."
   }
 }

--- a/escape/game.py
+++ b/escape/game.py
@@ -561,8 +561,18 @@ class Game:
             if next_name not in target["dirs"]:
                 node_data = self.deep_network_node.copy()
                 node_data["items"] = list(node_data["items"])
+                node_data["dirs"] = {}
                 if next_name == "node2":
                     node_data["items"].append("firmware.patch")
+                if next_name == "node3":
+                    node_data["items"].append("root.access")
+                override = (
+                    self.deep_network_node.get("dirs", {})
+                    .get(next_name, {})
+                    .get("desc")
+                )
+                if override:
+                    node_data["desc"] = override
                 target["dirs"][next_name] = node_data
                 self._output(f"Discovered {next_name} (locked).")
                 return
@@ -603,6 +613,9 @@ class Game:
                 return
             if target_name == "node3" and "firmware.patch" not in self.inventory:
                 self._output("You need the firmware.patch to hack this node.")
+                return
+            if target_name == "node4" and "root.access" not in self.inventory:
+                self._output("You need the root.access to hack this node.")
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -227,3 +227,95 @@ def test_hack_node3_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+
+
+def test_scan_node4_after_hack_node3():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node4' in out
+
+
+def test_hack_node4_requires_root_access():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'hack node4\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the root.access to hack this node.' in out
+
+
+def test_hack_node4_success():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'cd node4\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'deep.node.log' in out


### PR DESCRIPTION
## Summary
- expand the deep network template with a node4 description
- require a `root.access` item to hack node4
- drop deep copy for deep network dirs and generate `root.access` when discovering node3
- support custom descriptions for generated nodes
- add tests covering scan and hack of the new node4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550eee8768832aa179b12184c56eb4