### PR TITLE
Add Sage NPC

### DIFF
--- a/escape/data/npc/sage.dialog
+++ b/escape/data/npc/sage.dialog
@@ -1,0 +1,21 @@
+The sage sits quietly among ancient files.
+> Seek wisdom [+humble]
+> Demand secrets [-humble]
+> Leave silently
+"Patience reveals hidden truths."
+---
+?humble:The sage smiles gently at your approach.
+?!humble:The sage eyes you warily.
+> Ask about escape [+curious]
+> Ask about the fragment [+fragment]
+> Take your leave
+"Knowledge flows to those who listen."
+---
+?curious:The sage whispers that decoding the fragment will open new paths.
+?fragment:The sage notes the decoder in the lab may help.
+> Offer thanks [+grateful]
+> Depart
+"The path is yours to walk."
+---
+?grateful:The sage blesses your journey before returning to silence.
+?!grateful:The sage resumes quiet contemplation.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -19,7 +19,13 @@
         "items": [
           "old.note"
         ],
-        "dirs": {}
+        "dirs": {
+          "npc": {
+            "desc": "An old sage maintains the wisdom stored here.",
+            "items": [],
+            "dirs": {}
+          }
+        }
       },
       "core": {
         "desc": "The core systems thrum with latent energy.",
@@ -130,6 +136,10 @@
     "oracle": [
       "dream",
       "oracle"
+    ],
+    "sage": [
+      "archive",
+      "npc"
     ]
   },
   "item_descriptions": {

--- a/tests/test_npc_sage.py
+++ b/tests/test_npc_sage.py
@@ -1,0 +1,23 @@
+import subprocess
+import sys
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_sage_first_and_second_stage():
+    result = subprocess.run(
+        CMD,
+        input='cd archive\ncd npc\ntalk sage\n1\ntalk sage\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'sage sits quietly' in out
+    assert '1. Seek wisdom' in out
+    assert 'Patience reveals hidden truths.' in out
+    assert 'sage smiles gently at your approach' in out
+    assert 'Knowledge flows to those who listen.' in out
+    assert 'Goodbye' in out
+


### PR DESCRIPTION
## Summary
- introduce `sage.dialog` with multiple sections and flag choices
- add `sage` location and mapping to `npc_locations`
- provide basic conversation test for the Sage NPC

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855125f071c832aae56259fdb34fd83