### PR TITLE
Persist command history

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -765,6 +765,7 @@ class Game:
             "glitch_steps": self.glitch_steps,
             "npc_state": self.npc_state,
             "aliases": self.aliases,
+            "command_history": self.command_history,
         }
         try:
             with open(fname, "w", encoding="utf-8") as f:
@@ -797,6 +798,7 @@ class Game:
         self.glitch_steps = data.get("glitch_steps", 0)
         self.npc_state = data.get("npc_state", {})
         self.aliases = data.get("aliases", {})
+        self.command_history = data.get("command_history", [])
         self._output("Game loaded.")
 
     def _history(self) -> None:

--- a/tests/test_history_command.py
+++ b/tests/test_history_command.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_history_persists_after_save_load(tmp_path):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    subprocess.run(
+        CMD,
+        input='look\nsave\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+
+    result = subprocess.run(
+        CMD,
+        input='load\nhistory\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    out = result.stdout
+    assert '> look\nsave\nhistory' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- keep track of `command_history` across saves
- restore saved history on load
- test history persistence after saving and loading

## Testing
- `pytest tests/test_history_command.py::test_history_persists_after_save_load -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551417a13c832aa015f9de5375d566