### PR TITLE
Add journal command and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ unexpected ways.
     messages may appear.
   - `color on` / `color off` / `color toggle` – enable, disable or toggle ANSI colors
   - `history` – display the commands you've entered this session
+  - `journal` – view notes or `journal add <text>` to record a message
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them
   - `alias <name> <command>` – create a custom shortcut

--- a/escape/game.py
+++ b/escape/game.py
@@ -60,6 +60,9 @@ class Game:
         # store all commands the player enters this session
         self.command_history: list[str] = []
 
+        # notes recorded by the player
+        self.journal: list[str] = []
+
         # runtime command aliases created via the 'alias' command
         self.aliases: dict[str, str] = {}
 
@@ -91,6 +94,7 @@ class Game:
             "glitch": "Toggle glitch mode",
             "color": "Toggle ANSI color output",
             "history": "Show command history",
+            "journal": "View or add personal notes",
             "sleep": "Enter the dream state and rest",
             "restart": "Restart the game",
             "quit": "Exit the game",
@@ -126,6 +130,7 @@ class Game:
             "glitch": lambda arg="": self._toggle_glitch(),
             "color": lambda arg="": self._color(arg),
             "history": lambda arg="": self._history(),
+            "journal": lambda arg="": self._journal(arg),
             "sleep": lambda arg="": self._sleep(arg),
             "restart": lambda arg="": self._restart(),
             "quit": lambda arg="": self._quit(),
@@ -766,6 +771,7 @@ class Game:
             "npc_state": self.npc_state,
             "aliases": self.aliases,
             "command_history": self.command_history,
+            "journal": self.journal,
         }
         try:
             with open(fname, "w", encoding="utf-8") as f:
@@ -799,6 +805,7 @@ class Game:
         self.npc_state = data.get("npc_state", {})
         self.aliases = data.get("aliases", {})
         self.command_history = data.get("command_history", [])
+        self.journal = data.get("journal", [])
         self._output("Game loaded.")
 
     def _history(self) -> None:
@@ -808,6 +815,26 @@ class Game:
                 self._output(entry)
         else:
             self._output("No commands entered.")
+
+    def _journal(self, arg: str = "") -> None:
+        """List notes or append a new one."""
+        arg = arg.strip()
+        if not arg:
+            if not self.journal:
+                self._output("Journal is empty.")
+            else:
+                for note in self.journal:
+                    self._output(note)
+            return
+        if arg.lower().startswith("add "):
+            text = arg[4:].strip()
+            if not text:
+                self._output("Usage: journal add <text>")
+                return
+            self.journal.append(text)
+            self._output("Note added.")
+        else:
+            self._output("Usage: journal [add <text>]")
 
     def _alias(self, arg: str) -> None:
         """Create a new alias or list existing aliases."""

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,26 @@
+from escape import Game
+
+
+def test_journal_add_and_list(capsys):
+    game = Game()
+    game._journal("add first note")
+    game._journal("add second note")
+    out = capsys.readouterr().out
+    assert out.count("Note added.") == 2
+    game._journal()
+    out = capsys.readouterr().out
+    assert "first note" in out
+    assert "second note" in out
+
+
+def test_journal_persistence(tmp_path):
+    game = Game()
+    game.save_file = tmp_path / "game.sav"
+    game._journal("add remember this")
+    game._save()
+
+    new_game = Game()
+    new_game.save_file = game.save_file
+    new_game._load()
+    assert new_game.journal == ["remember this"]
+


### PR DESCRIPTION
## Summary
- allow players to keep a journal of notes
- save/load journal entries along with the rest of the game
- document the new command
- test journal functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685518fef184832ab94ee01230389dce