### PR TITLE
Extend network with node5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ unexpected ways.
    - `lab/` – a cluttered research area humming with equipment
   - `archive/` – dusty shelves of old backups and forgotten notes
   - `core/npc/` – a secluded nook where a daemon awaits interaction
-  - `network/` – a tangle of digital links hiding a locked node
+  - `network/` – a tangle of digital links hiding a chain of nodes down to `node5`
   - `dream/oracle/` – an enigmatic hall where the oracle offers cryptic advice
 
 ## Running Tests

--- a/VISIONDOCUMENT.md
+++ b/VISIONDOCUMENT.md
@@ -72,6 +72,7 @@ Endings include:
 * Exploration-based narrative with branching outcomes
 * Light puzzle-solving via command chaining (e.g., `use decompiler on access.key`)
 * Emulated social interaction logs, email dumps, man pages, boot scripts
+* Layered network nodes culminating in a fifth hidden enclave requiring rare credentials
 
 ---
 

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -112,6 +112,9 @@
     "dirs": {
       "node4": {
         "desc": "The deepest node rumored to grant root access."
+      },
+      "node5": {
+        "desc": "A final node said to hold the master process."
       }
     },
     "locked": true
@@ -160,6 +163,7 @@
     "auth.token": "A multi-factor token used for deeper authentication.",
     "deep.node.log": "Diagnostics from the heart of the network.",
     "firmware.patch": "A subtle exploit enabling access to even deeper nodes.",
-    "root.access": "Credentials granting unrestricted control over the system."
+    "root.access": "Credentials granting unrestricted control over the system.",
+    "super.user": "An elite credential needed for the deepest hacks."
   }
 }

--- a/escape/game.py
+++ b/escape/game.py
@@ -571,6 +571,8 @@ class Game:
                     node_data["items"].append("firmware.patch")
                 if next_name == "node3":
                     node_data["items"].append("root.access")
+                if next_name == "node4":
+                    node_data["items"].append("super.user")
                 override = (
                     self.deep_network_node.get("dirs", {})
                     .get(next_name, {})
@@ -621,6 +623,9 @@ class Game:
                 return
             if target_name == "node4" and "root.access" not in self.inventory:
                 self._output("You need the root.access to hack this node.")
+                return
+            if target_name == "node5" and "super.user" not in self.inventory:
+                self._output("You need the super.user to hack this node.")
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -319,3 +319,107 @@ def test_hack_node4_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+
+
+def test_scan_node5_after_hack_node4():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node5' in out
+
+
+def test_hack_node5_requires_super_user():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'hack node5\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the super.user to hack this node.' in out
+
+
+def test_hack_node5_success():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'cd node5\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'deep.node.log' in out


### PR DESCRIPTION
## Summary
- add node5 stub to deep_network_node and item `super.user`
- enable scanning/hacking node5 requiring the new credential
- document the additional depth in README and VISIONDOCUMENT
- place new item in node4 when node5 discovered
- test scanning and hacking node5

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68551aae38e4832ab162287ebed12664