### PR TITLE
Add directory option to look command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ unexpected ways.
    python -m escape
    ```
    Use `help` (or `h`) inside the game for available commands and `quit` (or `exit`) to exit.
-   Common command aliases like `i`/`inv` for `inventory` and `look around` for `look` are also supported.
+   Common command aliases like `i`/`inv` for `inventory` and `look around` for `look` are also supported. You can also `look <dir>` to preview a subdirectory without entering it.
 
    **Core commands**
-   - `look` / `look around` – describe the current room
+   - `look [dir]` / `look around` – describe the current room or a subdirectory
    - `take <item>` / `drop <item>` – manage inventory items
    - `inventory` / `i` / `inv` – show what you're carrying
    - `examine <item>` – get a closer look at an object

--- a/escape/game.py
+++ b/escape/game.py
@@ -73,7 +73,7 @@ class Game:
         # descriptions for help output
         self.command_descriptions = {
             "help": "Show help for commands",
-            "look": "Describe the current room",
+            "look": "Describe the current room or a subdirectory",
             "ls": "List items and subdirectories",
             "cd": "Change directory",
             "pwd": "Show current path",
@@ -106,7 +106,7 @@ class Game:
         self.command_map = {
             "help": lambda arg="": self._print_help(arg.strip()),
             "h": lambda arg="": self._print_help(arg.strip()),
-            "look": lambda arg="": self._look(),
+            "look": lambda arg="": self._look(arg),
             "look around": lambda arg="": self._look(),
             "ls": lambda arg="": self._ls(),
             "pwd": lambda arg="": self._pwd(),
@@ -378,8 +378,14 @@ class Game:
             node = node["dirs"][part]
         return node
 
-    def _look(self):
+    def _look(self, directory: str = "") -> None:
         node = self._current_node()
+        directory = directory.strip()
+        if directory:
+            if directory not in node["dirs"]:
+                self._output(f"No such directory: {directory}")
+                return
+            node = node["dirs"][directory]
         self._output(node["desc"])
         entries = [d + "/" for d in node["dirs"]] + list(node["items"])
         if entries:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -108,6 +108,18 @@ def test_look_around_alias():
     assert 'Goodbye' in result.stdout
 
 
+def test_look_specific_directory():
+    result = subprocess.run(
+        CMD,
+        input='look lab\npwd\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'cluttered research lab' in out
+    assert '> /' in out
+
+
 def test_help_alias():
     result = subprocess.run(
         CMD,
@@ -127,7 +139,7 @@ def test_help_specific_command():
         capture_output=True,
     )
     out = result.stdout
-    assert 'look: Describe the current room' in out
+    assert 'look: Describe the current room or a subdirectory' in out
     assert 'Goodbye' in out
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -38,6 +38,6 @@ def test_help_then_look():
         capture_output=True,
     )
     out = result.stdout
-    assert 'look: Describe the current room' in out
+    assert 'look: Describe the current room or a subdirectory' in out
     assert 'dimly lit terminal' in out
     assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- extend `look` to preview subdirectories
- pass args to `look` in command map
- document directory preview in README and help text
- test new `look lab` behaviour and update expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551bfb79b4832a86c24d905370678f