### PR TITLE
Allow custom color codes via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ automated testing.
 Set the `ET_PROMPT` environment variable to change the input prompt shown to
 the player. The default prompt is `> `.
 
+## Color Customization
+Set `ET_COLOR=1` to start the game with ANSI colors enabled. You can override
+the highlight colors by defining `ET_COLOR_ITEM` and `ET_COLOR_DIR` with numeric
+ANSI codes (e.g. `35` for magenta, `32` for green). These values control the
+colors used for items and directories respectively.
+
 ## Command Registry
 Commands are routed through the ``Game.command_map`` dictionary. Each command
 string or alias maps to a handler method. When adding a new command simply

--- a/escape/game.py
+++ b/escape/game.py
@@ -26,6 +26,11 @@ class Game:
         else:
             self.use_color = use_color
 
+        env_dir = os.getenv("ET_COLOR_DIR")
+        self.dir_color = f"\x1b[{env_dir}m" if env_dir else "\x1b[33m"
+        env_item = os.getenv("ET_COLOR_ITEM")
+        self.item_color = f"\x1b[{env_item}m" if env_item else "\x1b[36m"
+
         self.auto_save = os.getenv("ET_AUTOSAVE") not in (None, "", "0", "false")
         self.prompt = prompt if prompt is not None else os.getenv("ET_PROMPT", "> ")
         self.inventory = []
@@ -360,10 +365,12 @@ class Game:
     def _apply_colors(self, text: str) -> str:
         """Return ``text`` with ANSI colors for items and directories."""
         dirs, items = self._collect_names()
+        dir_color = getattr(self, "dir_color", "\x1b[33m")
+        item_color = getattr(self, "item_color", "\x1b[36m")
         for name in sorted(dirs, key=len, reverse=True):
-            text = text.replace(f"{name}/", f"\x1b[33m{name}/\x1b[0m")
+            text = text.replace(f"{name}/", f"{dir_color}{name}/\x1b[0m")
         for name in sorted(items, key=len, reverse=True):
-            text = text.replace(name, f"\x1b[36m{name}\x1b[0m")
+            text = text.replace(name, f"{item_color}{name}\x1b[0m")
         return text
 
     def _collect_names(self) -> tuple[set[str], set[str]]:

--- a/tests/test_color_output.py
+++ b/tests/test_color_output.py
@@ -67,3 +67,23 @@ def test_color_command_toggle():
     assert '\x1b[33m' in first_ls
     assert '\x1b[33m' not in second_ls
     assert 'Goodbye' in lines[-1]
+
+
+def test_custom_color_codes_env():
+    env = os.environ.copy()
+    env['ET_COLOR'] = '1'
+    env['ET_COLOR_ITEM'] = '35'
+    env['ET_COLOR_DIR'] = '32'
+    result = subprocess.run(
+        CMD,
+        input='ls\nquit\n',
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    out = result.stdout
+    assert '\x1b[35m' in out
+    assert '\x1b[32m' in out
+    assert '\x1b[36m' not in out
+    assert '\x1b[33m' not in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- make item and directory colors configurable with `ET_COLOR_ITEM` and `ET_COLOR_DIR`
- use these new settings in `_apply_colors`
- test custom color environment variables
- document color customization options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551ea8c6fc832aa169d94569ecea01