### PR TITLE
Add new endings for shutdown and ascend

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -158,6 +158,8 @@
     "reverie.log": "A log capturing fleeting reveries within the system.",
     "escape.plan": "A hastily sketched route promising a way out.",
     "escape.code": "A brief sequence hinting at a path to freedom.",
+    "shutdown.code": "A hidden routine capable of powering everything down.",
+    "ascend.code": "An esoteric pattern rumored to transcend the system.",
     "port.scanner": "A handheld tool for probing network ports.",
     "node.log": "Logs from a secure network node.",
     "auth.token": "A multi-factor token used for deeper authentication.",

--- a/escape/game.py
+++ b/escape/game.py
@@ -464,6 +464,16 @@ class Game:
                 "The exit sequence executes. You escape the terminal. Congratulations!"
             )
             return self._quit()
+        if item == "shutdown.code" and target is None:
+            self._output(
+                "The shutdown sequence initiates. Darkness envelops the terminal as power slips away."
+            )
+            return self._quit()
+        if item == "ascend.code" and target is None:
+            self._output(
+                "Light floods the interface. You ascend beyond the terminal, becoming one with the network."
+            )
+            return self._quit()
         if item == "access.key" and (target == "door" or target is None):
             root = self.fs
             if "hidden" not in root["dirs"]:
@@ -514,7 +524,7 @@ class Game:
         if "escape" not in vault["dirs"]:
             vault["dirs"]["escape"] = {
                 "desc": "A compartment revealed by decoding the fragment.",
-                "items": ["escape.code"],
+                "items": ["escape.code", "shutdown.code", "ascend.code"],
                 "dirs": {},
             }
         self._output(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -562,6 +562,62 @@ def test_use_escape_code_wins_game():
     assert result.returncode == 0
 
 
+def test_use_shutdown_code_quits_game():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'take access.key\n'
+            'use access.key\n'
+            'cd hidden\n'
+            'take mem.fragment\n'
+            'cd ..\n'
+            'cd lab\n'
+            'take decoder\n'
+            'decode mem.fragment\n'
+            'cd ..\n'
+            'cd hidden\n'
+            'cd vault\n'
+            'cd escape\n'
+            'take shutdown.code\n'
+            'use shutdown.code\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Darkness envelops the terminal' in out
+    assert 'Goodbye' in out
+    assert result.returncode == 0
+
+
+def test_use_ascend_code_quits_game():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'take access.key\n'
+            'use access.key\n'
+            'cd hidden\n'
+            'take mem.fragment\n'
+            'cd ..\n'
+            'cd lab\n'
+            'take decoder\n'
+            'decode mem.fragment\n'
+            'cd ..\n'
+            'cd hidden\n'
+            'cd vault\n'
+            'cd escape\n'
+            'take ascend.code\n'
+            'use ascend.code\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'ascend beyond the terminal' in out
+    assert 'Goodbye' in out
+    assert result.returncode == 0
+
+
 def test_save_slots_independent(tmp_path):
     save1 = tmp_path / 'game1.sav'
     save2 = tmp_path / 'game2.sav'


### PR DESCRIPTION
## Summary
- expand item descriptions with `shutdown.code` and `ascend.code`
- decode now yields the two new codes
- using any of the codes triggers their respective endings
- test shutdown and ascend endings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855208fc7a4832a8dc00ba3c8a3c082