### PR TITLE
Add CLI options for prompt, autosave, and seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,19 @@ three generated locations, sometimes containing unique items. Set the
 `ET_EXTRA_SEED` environment variable before launching to make this generation
 deterministic for reproducible testing or custom scenarios.
 You can also set `ET_EXTRA_COUNT` to control exactly how many extra directories
-are created under each base path.
+are created under each base path. The same seed can be supplied on the command
+line via ``--seed <num>``.
 
 ## Autosave
 Set the `ET_AUTOSAVE` environment variable to automatically write `game.sav`
 after every successful command. This is handy for continuous progress backups or
-automated testing.
+automated testing. Running ``escape-terminal --autosave`` enables the same
+behavior without setting the environment variable.
 
 ## Custom Prompt
 Set the `ET_PROMPT` environment variable to change the input prompt shown to
-the player. The default prompt is `> `.
+the player. The default prompt is `> `. You can also pass ``--prompt <text>`` on
+the command line.
 
 ## Color Customization
 Set `ET_COLOR=1` to start the game with ANSI colors enabled. You can override

--- a/escape/cli.py
+++ b/escape/cli.py
@@ -10,8 +10,26 @@ def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(description="Escape the Terminal")
     parser.add_argument("--color", action="store_true", help="enable ANSI colors")
     parser.add_argument("--world", metavar="file", help="path to custom world JSON")
+    parser.add_argument("--prompt", metavar="text", help="custom input prompt")
+    parser.add_argument(
+        "--autosave",
+        action="store_true",
+        help="autosave after each command",
+    )
+    parser.add_argument(
+        "--seed",
+        metavar="num",
+        help="seed for procedural extras",
+    )
     args = parser.parse_args(argv)
 
+    import os
+
+    if args.autosave:
+        os.environ["ET_AUTOSAVE"] = "1"
+    if args.seed is not None:
+        os.environ["ET_EXTRA_SEED"] = str(args.seed)
+
     game_color = True if args.color else None
-    Game(use_color=game_color, world_file=args.world).run()
+    Game(use_color=game_color, world_file=args.world, prompt=args.prompt).run()
 

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import sys
+
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_prompt_flag():
+    result = subprocess.run(
+        CMD + ['--prompt', '>>> '],
+        input='quit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert '>>> Goodbye' in result.stdout
+
+
+def test_autosave_flag(tmp_path):
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.path.dirname(os.path.dirname(__file__))
+    subprocess.run(
+        CMD + ['--autosave'],
+        input='look\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert (tmp_path / 'game.sav').exists()
+
+
+def test_seed_flag():
+    result = subprocess.run(
+        CMD + ['--seed', '123'],
+        input='cd dream\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'neon_hall_0/' in result.stdout


### PR DESCRIPTION
## Summary
- extend the `escape` CLI with `--prompt`, `--autosave` and `--seed`
- document the new flags in the README
- test the new CLI options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685521dd90b0832ab60ebb959daa5e46