### PR TITLE
Add dialog validator entry point

### DIFF
--- a/docs/NPC_DIALOG.md
+++ b/docs/NPC_DIALOG.md
@@ -39,7 +39,11 @@ Game.npc_locations['merchant'] = ['market', 'npc']
 This places a new `merchant.dialog` under `data/npc/` and associates it with the `market/npc/` location.
 
 ## Validator script
-A small helper lives at `escape/utils/validate_dialog.py` to check dialog files for common mistakes. Run it with Python and pass one or more files or directories:
+A small helper lives at `escape/utils/validate_dialog.py` to check dialog files for common mistakes. Run it with Python and pass one or more files or directories or use the `validate-dialog` command installed with the game:
+
+```bash
+validate-dialog escape/data/npc
+```
 
 ```bash
 python -m escape.utils.validate_dialog escape/data/npc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.8"
 
 [project.scripts]
 escape-terminal = "escape.cli:main"
+validate-dialog = "escape.utils.validate_dialog:main"
 
 [tool.setuptools]
 packages = ["escape"]

--- a/tests/test_validate_dialog.py
+++ b/tests/test_validate_dialog.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def test_validate_dialog(tmp_path):
+    good = tmp_path / "good.dialog"
+    good.write_text("Hello\n> Continue [flag]\n?flag: done\n")
+
+    bad = tmp_path / "bad.dialog"
+    bad.write_text("Oops\n> Broken [flag\n?missing colon\n")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = REPO_ROOT
+
+    ok = subprocess.run(
+        [sys.executable, "-m", "escape.utils.validate_dialog", str(good)],
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert ok.returncode == 0
+
+    err = subprocess.run(
+        [sys.executable, "-m", "escape.utils.validate_dialog", str(bad)],
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert err.returncode == 1
+    assert "choice missing closing ']'" in err.stderr
+    assert "conditional missing ':'" in err.stderr


### PR DESCRIPTION
## Summary
- expose a new `validate-dialog` console script
- document validation helper usage in NPC dialog docs
- test dialog validator on sample files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685524ed8be0832a94d62e7ac4bd1117