### PR TITLE
Extend deep network nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ unexpected ways.
    - `lab/` – a cluttered research area humming with equipment
   - `archive/` – dusty shelves of old backups and forgotten notes
   - `core/npc/` – a secluded nook where a daemon awaits interaction
-  - `network/` – a tangle of digital links hiding a chain of nodes down to `node5`
+  - `network/` – a tangle of digital links hiding a chain of nodes down to `node7`
   - `dream/oracle/` – an enigmatic hall where the oracle offers cryptic advice
 
 ## Running Tests

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -115,6 +115,12 @@
       },
       "node5": {
         "desc": "A final node said to hold the master process."
+      },
+      "node6": {
+        "desc": "A secret admin console hidden from ordinary scans."
+      },
+      "node7": {
+        "desc": "The mythical kernel node rumored to run everything."
       }
     },
     "locked": true
@@ -166,6 +172,9 @@
     "deep.node.log": "Diagnostics from the heart of the network.",
     "firmware.patch": "A subtle exploit enabling access to even deeper nodes.",
     "root.access": "Credentials granting unrestricted control over the system.",
-    "super.user": "An elite credential needed for the deepest hacks."
+    "super.user": "An elite credential needed for the deepest hacks.",
+    "admin.override": "A privileged script to override admin-level security.",
+    "kernel.key": "The master key granting access to the kernel node.",
+    "master.process": "A mysterious executable rumored to control it all."
   }
 }

--- a/escape/game.py
+++ b/escape/game.py
@@ -639,6 +639,12 @@ class Game:
                     node_data["items"].append("root.access")
                 if next_name == "node4":
                     node_data["items"].append("super.user")
+                if next_name == "node5":
+                    node_data["items"].append("admin.override")
+                if next_name == "node6":
+                    node_data["items"].append("kernel.key")
+                if next_name == "node7":
+                    node_data["items"].append("master.process")
                 override = (
                     self.deep_network_node.get("dirs", {})
                     .get(next_name, {})
@@ -692,6 +698,12 @@ class Game:
                 return
             if target_name == "node5" and "super.user" not in self.inventory:
                 self._output("You need the super.user to hack this node.")
+                return
+            if target_name == "node6" and "admin.override" not in self.inventory:
+                self._output("You need the admin.override to hack this node.")
+                return
+            if target_name == "node7" and "kernel.key" not in self.inventory:
+                self._output("You need the kernel.key to hack this node.")
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -423,3 +423,247 @@ def test_hack_node5_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+
+
+def test_scan_node6_after_hack_node5():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node6' in out
+
+
+def test_hack_node6_requires_admin_override():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'hack node6\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the admin.override to hack this node.' in out
+
+
+def test_hack_node6_success():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'cd node6\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'kernel.key' in out
+
+
+def test_scan_node7_after_hack_node6():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered node7' in out
+
+
+def test_hack_node7_requires_kernel_key():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'cd node6\n'
+            'hack node7\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the kernel.key to hack this node.' in out
+
+
+def test_hack_node7_success():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'cd node6\n'
+            'take kernel.key\n'
+            'hack node7\n'
+            'cd node7\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'master.process' in out


### PR DESCRIPTION
## Summary
- flesh out deeper nodes in `world.json`
- add new credentials and kernel artifacts for deeper nodes
- support scanning and hacking for node6 and node7
- mention deeper node chain in the README
- test additional network progression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552726013c832a982e764451161d27