### PR TITLE
Add plugin development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
 NPC located under ``dream/oracle/``.
 
 ## Plugins
+See [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md) for a full guide on creating and loading plugins.
+
 Python files placed in ``escape/plugins/`` are discovered on startup. The game
 scans this directory for ``*.py`` modules (ignoring names beginning with
 ``__``) and imports each one. Plugins are loaded inside ``Game._load_plugins``
@@ -142,6 +144,9 @@ which injects the active ``Game`` instance into each module before executing
 it. Plugin directories may also contain ``*.zip`` archives. Each archive is
 treated as a module named after the zip file and loaded via
 ``zipimport.zipimporter``:
+
+You can add additional plugin directories by setting the `ET_PLUGIN_PATH` environment variable to one or more paths separated by the system path separator.
+
 
 ```python
 for path in plugins_dir.glob("*.py"):

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -1,0 +1,56 @@
+# Plugin Development
+
+EscapeTheTerminal supports optional plugins that extend the game with new commands or behaviour. Plugins are discovered at startup and may live either in the built in `escape/plugins/` directory or in additional paths specified through the `ET_PLUGIN_PATH` environment variable.
+
+``ET_PLUGIN_PATH`` may contain one or more directories separated by the operating system path separator (``:`` on Unix-like systems, ``;`` on Windows). Each directory is scanned for ``*.py`` files and ``*.zip`` archives and everything found is imported as a module.
+
+## Simple ``.py`` Plugin
+
+Create a Python file inside a plugin directory and register commands as soon as the module is imported. Every plugin receives the running ``game`` instance as a global variable.
+
+```python
+# greet.py
+
+def greet(name=""):
+    game._output(f"Greetings, {name}!" if name else "Greetings!")
+
+if 'game' in globals():
+    game.command_map['greet'] = lambda arg="": greet(arg)
+```
+
+Place ``greet.py`` under ``escape/plugins/`` or a directory listed in ``ET_PLUGIN_PATH`` and launch the game. The ``greet`` command will be available immediately.
+
+## ``.zip`` Plugin Example
+
+Plugins can also be distributed as zip archives. The archive should contain a single Python module. The name of the zip file becomes the module name when loaded.
+
+```text
+hello.zip
+    hello.py
+```
+
+`hello.py` could look like:
+
+```python
+def hello(arg=""):
+    game._output("Hello from zip")
+
+if 'game' in globals():
+    game.command_map['hello'] = lambda arg="": hello(arg)
+```
+
+Put ``hello.zip`` in a plugin directory and run the game to use the ``hello`` command.
+
+## Loading Plugins
+
+On startup the game imports all plugins from ``escape/plugins/``. If ``ET_PLUGIN_PATH`` is defined, its directories are processed as well. For example:
+
+```bash
+ET_PLUGIN_PATH=/path/to/mods:/other/plugins escape-terminal
+```
+
+This would load plugins from ``/path/to/mods`` and ``/other/plugins`` in addition to the bundled ones.
+
+Plugins execute arbitrary Python code so only use plugins from trusted sources.
+
+


### PR DESCRIPTION
## Summary
- document plugin development in docs/PLUGIN_DEVELOPMENT.md
- mention the ET_PLUGIN_PATH variable and zipped plugins
- link new guide from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552824fe00832aaaa1bab5c8fbb19e