### PR TITLE
Add runtime network node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,4 +199,5 @@ cython_debug/
 !data/escape.plan
 !data/node.log
 !data/deep.node.log
+!data/runtime.log
 data/logs/

--- a/escape/data/runtime.log
+++ b/escape/data/runtime.log
@@ -1,0 +1,1 @@
+A log revealing your runtime environment and history.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -121,6 +121,9 @@
       },
       "node7": {
         "desc": "The mythical kernel node rumored to run everything."
+      },
+      "runtime": {
+        "desc": "A hidden runtime environment monitoring your every command."
       }
     },
     "locked": true
@@ -175,6 +178,7 @@
     "super.user": "An elite credential needed for the deepest hacks.",
     "admin.override": "A privileged script to override admin-level security.",
     "kernel.key": "The master key granting access to the kernel node.",
-    "master.process": "A mysterious executable rumored to control it all."
+    "master.process": "A mysterious executable rumored to control it all.",
+    "runtime.log": "A record detailing your own execution environment."
   }
 }

--- a/escape/game.py
+++ b/escape/game.py
@@ -640,7 +640,10 @@ class Game:
                     idx = int(directory[4:])
                 except ValueError:
                     idx = 1
-            next_name = f"node{idx+1}"
+            if idx >= 7:
+                next_name = "runtime"
+            else:
+                next_name = f"node{idx+1}"
             if next_name not in target["dirs"]:
                 node_data = self.deep_network_node.copy()
                 node_data["items"] = list(node_data["items"])
@@ -657,6 +660,8 @@ class Game:
                     node_data["items"].append("kernel.key")
                 if next_name == "node7":
                     node_data["items"].append("master.process")
+                if next_name == "runtime":
+                    node_data["items"].append("runtime.log")
                 override = (
                     self.deep_network_node.get("dirs", {})
                     .get(next_name, {})
@@ -699,7 +704,7 @@ class Game:
         if "port.scanner" not in self.inventory:
             self._output("You need the port.scanner to hack this node.")
             return
-        if target_name.startswith("node") and target_name != "node":
+        if (target_name.startswith("node") and target_name != "node") or target_name == "runtime":
             if "auth.token" not in self.inventory:
                 self._output("You need the auth.token to hack this node.")
                 return
@@ -717,6 +722,9 @@ class Game:
                 return
             if target_name == "node7" and "kernel.key" not in self.inventory:
                 self._output("You need the kernel.key to hack this node.")
+                return
+            if target_name == "runtime" and "master.process" not in self.inventory:
+                self._output("You need the master.process to hack this node.")
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -667,3 +667,143 @@ def test_hack_node7_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'master.process' in out
+
+
+def test_scan_runtime_after_hack_node7():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'cd node6\n'
+            'take kernel.key\n'
+            'hack node7\n'
+            'scan node7\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Discovered runtime' in out
+
+
+def test_hack_runtime_requires_master_process():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'cd node6\n'
+            'take kernel.key\n'
+            'hack node7\n'
+            'scan node7\n'
+            'cd node7\n'
+            'hack runtime\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'You need the master.process to hack this node.' in out
+
+
+def test_hack_runtime_success():
+    result = subprocess.run(
+        CMD,
+        input=(
+            'cd lab\n'
+            'take port.scanner\n'
+            'cd ..\n'
+            'scan network\n'
+            'hack network\n'
+            'cd network\n'
+            'scan node\n'
+            'cd node\n'
+            'take auth.token\n'
+            'hack node2\n'
+            'scan node2\n'
+            'cd node2\n'
+            'take firmware.patch\n'
+            'hack node3\n'
+            'scan node3\n'
+            'cd node3\n'
+            'take root.access\n'
+            'hack node4\n'
+            'scan node4\n'
+            'cd node4\n'
+            'take super.user\n'
+            'hack node5\n'
+            'scan node5\n'
+            'cd node5\n'
+            'take admin.override\n'
+            'hack node6\n'
+            'scan node6\n'
+            'cd node6\n'
+            'take kernel.key\n'
+            'hack node7\n'
+            'scan node7\n'
+            'cd node7\n'
+            'take master.process\n'
+            'hack runtime\n'
+            'cd runtime\n'
+            'ls\n'
+            'quit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'Access granted' in out
+    assert 'runtime.log' in out


### PR DESCRIPTION
## Summary
- expand `deep_network_node` with a new `runtime` node
- unlock runtime node when scanning/hacking deep network nodes
- describe the new `runtime.log` item
- track runtime log in git
- add tests for discovering and hacking the runtime node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552aad5e24832a9d70904e4e86591e