### PR TITLE
Add configurable save directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ after every successful command. This is handy for continuous progress backups or
 automated testing. Running ``escape-terminal --autosave`` enables the same
 behavior without setting the environment variable.
 
+`ET_SAVE_DIR` can be set to control where save files are stored. When unset,
+files are saved to the current working directory.
+
 ## Custom Prompt
 Set the `ET_PROMPT` environment variable to change the input prompt shown to
 the player. The default prompt is `> `. You can also pass ``--prompt <text>`` on

--- a/escape/game.py
+++ b/escape/game.py
@@ -61,6 +61,8 @@ class Game:
             "flashback.log": "Memories surge forth, revealing forgotten paths.",
         }
         self.save_file = "game.sav"
+        env_save_dir = os.getenv("ET_SAVE_DIR")
+        self.save_dir = Path(env_save_dir) if env_save_dir else Path.cwd()
         self.glitch_mode = False
         self.glitch_steps = 0
 
@@ -866,6 +868,7 @@ class Game:
     def _save(self, slot: str = ""):
         """Save game state to ``game<slot>.sav`` (default ``game.sav``)."""
         fname = self.save_file if not slot else f"game{slot}.sav"
+        path = self.save_dir / fname
         data = {
             "fs": self.fs,
             "inventory": self.inventory,
@@ -879,7 +882,7 @@ class Game:
             "score": self.score,
         }
         try:
-            with open(fname, "w", encoding="utf-8") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 import json
 
                 json.dump(data, f)
@@ -891,10 +894,11 @@ class Game:
     def _load(self, slot: str = ""):
         """Load game state from ``game<slot>.sav`` (default ``game.sav``)."""
         fname = self.save_file if not slot else f"game{slot}.sav"
+        path = self.save_dir / fname
         import json
 
         try:
-            with open(fname, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except FileNotFoundError:
             self._output("No save file found.")

--- a/tests/test_save_dir.py
+++ b/tests/test_save_dir.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_autosave_uses_save_dir(tmp_path):
+    save_dir = tmp_path / 'saves'
+    save_dir.mkdir()
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    env['ET_AUTOSAVE'] = '1'
+    env['ET_SAVE_DIR'] = str(save_dir)
+    subprocess.run(
+        CMD,
+        input='look\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert (save_dir / 'game.sav').exists()
+    assert not (tmp_path / 'game.sav').exists()
+
+
+def test_load_from_save_dir(tmp_path):
+    save_dir = tmp_path / 'saves'
+    save_dir.mkdir()
+    env = os.environ.copy()
+    env['PYTHONPATH'] = REPO_ROOT
+    env['ET_AUTOSAVE'] = '1'
+    env['ET_SAVE_DIR'] = str(save_dir)
+    subprocess.run(
+        CMD,
+        input='take access.key\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert (save_dir / 'game.sav').exists()
+
+    result = subprocess.run(
+        CMD,
+        input='load\ninventory\nquit\n',
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert 'Inventory: access.key' in result.stdout


### PR DESCRIPTION
## Summary
- make save directory configurable with `ET_SAVE_DIR`
- document the new `ET_SAVE_DIR` variable
- test saving and loading with `ET_SAVE_DIR`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552c117b50832aa42b81fbe866f8d1