### PR TITLE
Add dialog validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,18 @@ jobs:
       - name: Run tests
         run: |
           pytest -q
+
+  dialog-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Validate dialog files
+        run: |
+          python -m escape.utils.validate_dialog escape/data/npc

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The dreamer watches you closely.
 See [docs/NPC_DIALOG.md](docs/NPC_DIALOG.md) for the full file format. The helper
 script `python -m escape.utils.validate_dialog <path>` checks dialog files for
 common mistakes.
+Dialog files committed under `escape/data/npc` are automatically validated in
+the CI workflow.
 
 Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.


### PR DESCRIPTION
## Summary
- validate NPC dialog files in `escape/data/npc` during CI
- mention automatic dialog validation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552e709838832aa1bb4182a6873589