### PR TITLE
Add man command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ unexpected ways.
     messages may appear.
   - `color on` / `color off` / `color toggle` – enable, disable or toggle ANSI colors
   - `history` – display the commands you've entered this session
+  - `man <command>` – show the manual page for a command
   - `journal` – view notes or `journal add <text>` to record a message
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them

--- a/escape/data/man/look.man
+++ b/escape/data/man/look.man
@@ -1,0 +1,2 @@
+look - describe the current room or a subdirectory
+Usage: look [dir] or look around

--- a/escape/data/man/ls.man
+++ b/escape/data/man/ls.man
@@ -1,0 +1,2 @@
+ls - list items and subdirectories in the current directory
+Usage: ls

--- a/escape/game.py
+++ b/escape/game.py
@@ -82,6 +82,7 @@ class Game:
         # descriptions for help output
         self.command_descriptions = {
             "help": "Show help for commands",
+            "man": "Show a manual page for a command",
             "look": "Describe the current room or a subdirectory",
             "ls": "List items and subdirectories",
             "cd": "Change directory",
@@ -116,6 +117,7 @@ class Game:
         self.command_map = {
             "help": lambda arg="": self._print_help(arg.strip()),
             "h": lambda arg="": self._print_help(arg.strip()),
+            "man": lambda arg="": self._man(arg),
             "look": lambda arg="": self._look(arg),
             "look around": lambda arg="": self._look(),
             "ls": lambda arg="": self._ls(),
@@ -580,6 +582,23 @@ class Game:
             msg = self.use_messages.get("daemon.log")
             if msg:
                 self._output(msg)
+
+    def _man(self, command: str) -> None:
+        """Display a manual page for ``command`` from data/man."""
+        cmd = command.strip()
+        if not cmd:
+            self._output("Usage: man <command>")
+            return
+        path = self.data_dir / "man" / f"{cmd}.man"
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            self._output(f"No manual entry for {cmd}")
+            return
+        except OSError as exc:
+            self._output(f"Failed to read {cmd}: {exc}")
+            return
+        self._output(text.rstrip())
 
     def _grep(self, arg: str) -> None:
         """Print lines from log files matching ``pattern``.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -296,6 +296,18 @@ def test_cat_command():
     assert 'Goodbye' in result.stdout
 
 
+def test_man_look():
+    result = subprocess.run(
+        CMD,
+        input='man look\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'describe the current room' in out
+    assert 'Goodbye' in out
+
+
 def test_use_voice_log():
     result = subprocess.run(
         CMD,


### PR DESCRIPTION
## Summary
- add manual directory and example pages
- implement `Game._man` method and register `man` command
- document the new command in README
- test that `man look` prints manual text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552f9026e4832aa6554b58a195257c