### PR TITLE
Enable runtime node with kernel key

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -123,7 +123,7 @@
         "desc": "The mythical kernel node rumored to run everything."
       },
       "runtime": {
-        "desc": "A hidden runtime environment monitoring your every command."
+        "desc": "An experimental runtime environment logging each command."
       }
     },
     "locked": true

--- a/escape/game.py
+++ b/escape/game.py
@@ -748,8 +748,8 @@ class Game:
             if target_name == "node7" and "kernel.key" not in self.inventory:
                 self._output("You need the kernel.key to hack this node.")
                 return
-            if target_name == "runtime" and "master.process" not in self.inventory:
-                self._output("You need the master.process to hack this node.")
+            if target_name == "runtime" and "kernel.key" not in self.inventory:
+                self._output("You need the kernel.key to hack this node.")
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -713,7 +713,7 @@ def test_scan_runtime_after_hack_node7():
     assert 'Discovered runtime' in out
 
 
-def test_hack_runtime_requires_master_process():
+def test_hack_runtime_requires_kernel_key():
     result = subprocess.run(
         CMD,
         input=(
@@ -749,6 +749,7 @@ def test_hack_runtime_requires_master_process():
             'hack node7\n'
             'scan node7\n'
             'cd node7\n'
+            'drop kernel.key\n'
             'hack runtime\n'
             'quit\n'
         ),
@@ -756,7 +757,7 @@ def test_hack_runtime_requires_master_process():
         capture_output=True,
     )
     out = result.stdout
-    assert 'You need the master.process to hack this node.' in out
+    assert 'You need the kernel.key to hack this node.' in out
 
 
 def test_hack_runtime_success():
@@ -795,10 +796,9 @@ def test_hack_runtime_success():
             'hack node7\n'
             'scan node7\n'
             'cd node7\n'
-            'take master.process\n'
             'hack runtime\n'
             'cd runtime\n'
-            'ls\n'
+            'cat runtime.log\n'
             'quit\n'
         ),
         text=True,
@@ -806,4 +806,4 @@ def test_hack_runtime_success():
     )
     out = result.stdout
     assert 'Access granted' in out
-    assert 'runtime.log' in out
+    assert 'A log revealing your runtime environment and history.' in out


### PR DESCRIPTION
## Summary
- describe new runtime entry in world.json
- allow runtime node hacking via `kernel.key`
- update network tests for new runtime behavior

## Testing
- `pytest -q tests/test_network.py::test_hack_runtime_success tests/test_network.py::test_hack_runtime_requires_kernel_key -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855be56b3e4832aa76a6cc5e344af13