### PR TITLE
Add Archivist NPC in memory area

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -1,0 +1,19 @@
+The archivist catalogues swirling fragments with meticulous precision.
+> Ask about restoring memories [+curious]
+> Browse the catalog [-curious]
+> Leave
+"These records are fragile. Treat them kindly."
+---
+?curious:The archivist opens a secure drawer filled with numbered logs.
+?!curious:The archivist keeps the archives at a distance.
+> Inquire about hidden logs [+trust]
+> Step back
+"The key to recall lies within the fragment you carry."
+---
+?trust:The archivist hands you a faded index code.
+?!trust:The archivist resumes sorting without comment.
+> Thank the archivist
+> Depart
+"Remember: knowledge fades unless preserved."
+---
+The archivist files away another memory and says no more.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -70,7 +70,13 @@
         "items": [
           "flashback.log"
         ],
-        "dirs": {}
+        "dirs": {
+          "npc": {
+            "desc": "An archivist tends to the stored memories here.",
+            "items": [],
+            "dirs": {}
+          }
+        }
       },
       "network": {
         "desc": "Connections pulse faintly in this virtual mesh.",
@@ -151,6 +157,10 @@
     ],
     "sage": [
       "archive",
+      "npc"
+    ],
+    "archivist": [
+      "memory",
       "npc"
     ]
   },

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -119,3 +119,18 @@ def test_oracle_vision_stage():
     assert 'unveils a vision of hidden paths' in out
     assert 'images swirl before dissolving into noise' in out
     assert 'Goodbye' in out
+
+
+def test_archivist_progression():
+    result = subprocess.run(
+        CMD,
+        input='cd memory\ncd npc\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'archivist catalogues' in out
+    assert 'opens a secure drawer' in out
+    assert 'hands you a faded index code' in out
+    assert 'files away another memory' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add `archivist.dialog` with multiple dialog stages and flags
- register new memory/npc directory in `world.json` and map `archivist` NPC location
- test archivist conversation progression using flags

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c5d9e7a0832ab80060721f7ccb47