### PR TITLE
Add color theme plugin

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -57,4 +57,19 @@ This would load plugins from ``/path/to/mods`` and ``/other/plugins`` in additio
 
 Plugins execute arbitrary Python code so only use plugins from trusted sources.
 
+## Built-in Theme Plugin
+
+The repository ships with a small ``theme.py`` plugin located in
+``escape/plugins/``. It loads automatically and adds a ``theme`` command for
+changing the highlight colors at runtime.
+
+```
+theme dark   # blue directories, magenta items
+theme mono   # monochrome output
+theme neon   # bright green directories and magenta items
+```
+
+Running one of these commands sets ``game.dir_color`` and ``game.item_color`` to
+predefined ANSI codes.
+
 

--- a/escape/plugins/theme.py
+++ b/escape/plugins/theme.py
@@ -1,0 +1,19 @@
+THEMES = {
+    'dark': ("\x1b[34m", "\x1b[35m"),  # blue directories, magenta items
+    'mono': ("\x1b[37m", "\x1b[37m"),  # white directories and items
+    'neon': ("\x1b[92m", "\x1b[95m"),  # bright green dirs, bright magenta items
+}
+
+
+def theme(arg: str = "") -> None:
+    """Switch between predefined color themes."""
+    name = arg.strip().lower()
+    if name not in THEMES:
+        game._output("Usage: theme [dark|mono|neon]")
+        return
+    game.dir_color, game.item_color = THEMES[name]
+    game._output(f"Theme set to {name}.")
+
+
+if 'game' in globals():
+    game.command_map['theme'] = lambda arg="": theme(arg)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -99,3 +99,13 @@ def test_counter_plugin_state(monkeypatch, capsys, tmp_path):
         plugin_path.unlink(missing_ok=True)
         monkeypatch.delenv('ET_PLUGIN_PATH', raising=False)
         sys.modules.pop('my_counter', None)
+
+
+def test_theme_plugin(monkeypatch, capsys):
+    game = Game()
+    assert 'theme' in game.command_map
+    inputs = iter(['theme neon', 'quit'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    assert game.dir_color == '\x1b[92m'
+    assert game.item_color == '\x1b[95m'


### PR DESCRIPTION
## Summary
- add `theme` plugin for switching color styles
- document built-in `theme` plugin
- test that theme plugin registers and changes colors

## Testing
- `pip install -e '.[test]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c6feb974832ab65754bcfedd40f4