### PR TITLE
Add achievements command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ unexpected ways.
     messages may appear.
   - `color on` / `color off` / `color toggle` – enable, disable or toggle ANSI colors
   - `history` – display the commands you've entered this session
+  - `achievements` – list any achievements you've unlocked
   - `man <command>` – show the manual page for a command
   - `journal` – view notes or `journal add <text>` to record a message
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
@@ -197,4 +198,5 @@ Certain actions unlock persistent achievements stored in ``Game.achievements``.
 Use ``Game.unlock_achievement(name)`` to record one and ``Game.list_achievements``
 to retrieve the list. The mem.fragment decode and unlocking the ``runtime`` node
 award achievements out of the box. Achievements are saved along with other game
-state when using the ``save`` and ``load`` commands.
+state when using the ``save`` and ``load`` commands. Inside the game you can run
+the ``achievements`` command to display any that have been unlocked.

--- a/escape/game.py
+++ b/escape/game.py
@@ -108,6 +108,7 @@ class Game:
             "journal": "View or add personal notes",
             "sleep": "Enter the dream state and rest",
             "score": "Show your current score",
+            "achievements": "List unlocked achievements",
             "restart": "Restart the game",
             "quit": "Exit the game",
             "alias": "Create command shortcuts",
@@ -146,6 +147,7 @@ class Game:
             "journal": lambda arg="": self._journal(arg),
             "sleep": lambda arg="": self._sleep(arg),
             "score": lambda arg="": self._score(),
+            "achievements": lambda arg="": self._achievements(),
             "restart": lambda arg="": self._restart(),
             "quit": lambda arg="": self._quit(),
             "exit": lambda arg="": self._quit(),
@@ -503,6 +505,15 @@ class Game:
     def list_achievements(self) -> list[str]:
         """Return a copy of the unlocked achievements list."""
         return list(self.achievements)
+
+    def _achievements(self) -> None:
+        """Display unlocked achievements or a default message."""
+        names = self.list_achievements()
+        if names:
+            for name in names:
+                self._output(name)
+        else:
+            self._output("No achievements unlocked.")
 
     def _examine(self, item: str):
         node = self._current_node()

--- a/tests/test_achievements_command.py
+++ b/tests/test_achievements_command.py
@@ -1,0 +1,9 @@
+from escape import Game
+
+
+def test_achievements_command_lists_unlocked(capsys):
+    game = Game()
+    game.unlock_achievement("first")
+    game.command_map["achievements"]()
+    out = capsys.readouterr().out
+    assert "first" in out


### PR DESCRIPTION
## Summary
- add `achievements` command to `Game`
- test listing achievements after unlocking one
- document achievements command in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c9e90e50832ab2765dc9d32a90cc