### PR TITLE
Add --extra-count CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ three generated locations, sometimes containing unique items. Set the
 deterministic for reproducible testing or custom scenarios.
 You can also set `ET_EXTRA_COUNT` to control exactly how many extra directories
 are created under each base path. The same seed can be supplied on the command
-line via ``--seed <num>``.
+line via ``--seed <num>`` and the count via ``--extra-count <num>``.
 
 ## Autosave
 Set the `ET_AUTOSAVE` environment variable to automatically write `game.sav`

--- a/escape/cli.py
+++ b/escape/cli.py
@@ -21,6 +21,11 @@ def main(argv: list[str] | None = None):
         metavar="num",
         help="seed for procedural extras",
     )
+    parser.add_argument(
+        "--extra-count",
+        metavar="num",
+        help="number of extra directories per base",
+    )
     args = parser.parse_args(argv)
 
     import os
@@ -29,6 +34,8 @@ def main(argv: list[str] | None = None):
         os.environ["ET_AUTOSAVE"] = "1"
     if args.seed is not None:
         os.environ["ET_EXTRA_SEED"] = str(args.seed)
+    if args.extra_count is not None:
+        os.environ["ET_EXTRA_COUNT"] = str(args.extra_count)
 
     game_color = True if args.color else None
     Game(use_color=game_color, world_file=args.world, prompt=args.prompt).run()

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -37,3 +37,20 @@ def test_seed_flag():
         capture_output=True,
     )
     assert 'neon_hall_0/' in result.stdout
+
+
+def test_extra_count_flag():
+    result = subprocess.run(
+        CMD + ['--seed', '123', '--extra-count', '2'],
+        input=(
+            'cd dream\nls\ncd ..\n'
+            'cd memory\nls\ncd ..\n'
+            'cd core\nls\nquit\n'
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'misty_alcove_0/' in out
+    assert 'neon_alcove_0/' in out
+    assert 'echoing_hall_1/' in out


### PR DESCRIPTION
## Summary
- add `--extra-count` option to CLI
- export `ET_EXTRA_COUNT` when flag is used
- document new flag in README under Procedural Directories
- test that the flag controls directory generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855ce641058832a8d63fb3b85c1d971