### PR TITLE
Add prompt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ unexpected ways.
     stays active the stronger the corruption becomes and occasional glitch
     messages may appear.
   - `color on` / `color off` / `color toggle` – enable, disable or toggle ANSI colors
+  - `prompt [text]` – show or change the input prompt
   - `history` – display the commands you've entered this session
   - `achievements` – list any achievements you've unlocked
   - `man <command>` – show the manual page for a command
@@ -102,7 +103,7 @@ files are saved to the current working directory.
 ## Custom Prompt
 Set the `ET_PROMPT` environment variable to change the input prompt shown to
 the player. The default prompt is `> `. You can also pass ``--prompt <text>`` on
-the command line.
+the command line or use the in-game `prompt <text>` command.
 
 ## Color Customization
 Set `ET_COLOR=1` to start the game with ANSI colors enabled. You can override

--- a/escape/game.py
+++ b/escape/game.py
@@ -104,6 +104,7 @@ class Game:
             "load": "Load a saved game",
             "glitch": "Toggle glitch mode",
             "color": "Toggle ANSI color output",
+            "prompt": "Change or display the input prompt",
             "history": "Show command history",
             "journal": "View or add personal notes",
             "sleep": "Enter the dream state and rest",
@@ -143,6 +144,7 @@ class Game:
             "load": lambda arg="": self._load(arg),
             "glitch": lambda arg="": self._toggle_glitch(),
             "color": lambda arg="": self._color(arg),
+            "prompt": lambda arg="": self._prompt(arg),
             "history": lambda arg="": self._history(),
             "journal": lambda arg="": self._journal(arg),
             "sleep": lambda arg="": self._sleep(arg),
@@ -329,6 +331,15 @@ class Game:
             return
         state = "enabled" if self.use_color else "disabled"
         self._output(f"Color {state}.")
+
+    def _prompt(self, arg: str = "") -> None:
+        """Change or show the current input prompt."""
+        text = arg
+        if text.strip():
+            self.prompt = text
+            self._output(f"Prompt set to {self.prompt}")
+        else:
+            self._output(self.prompt)
 
     def _output(self, text: str = "") -> None:
         """Print text, applying glitch effects when enabled."""

--- a/tests/test_prompt_command.py
+++ b/tests/test_prompt_command.py
@@ -1,0 +1,12 @@
+from escape import Game
+
+
+def test_prompt_set_and_show(capsys):
+    game = Game()
+    game._prompt('>>> ')
+    out = capsys.readouterr().out
+    assert 'Prompt set to >>>' in out
+    assert game.prompt == '>>> '
+    game._prompt('')
+    out = capsys.readouterr().out
+    assert out.strip() == '>>>'


### PR DESCRIPTION
## Summary
- enable changing the prompt at runtime with a new `prompt` command
- show or change prompt text
- document the command in README
- test the new behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfad4748832a9414321ff2721bbc