### PR TITLE
Introduce glitched dialog flag

### DIFF
--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -1,4 +1,6 @@
 The dreamer watches you closely.
+?glitched:The dreamer flickers with digital noise.
+?!glitched:The dreamer seems stable.
 > Ask about escape
 > Ask about dreams
 > Ask about the fragment

--- a/escape/game.py
+++ b/escape/game.py
@@ -841,6 +841,8 @@ class Game:
         else:
             state = int(entry)
             flags = {}
+        # inject a dynamic flag when glitch mode is active
+        flags["glitched"] = self.glitch_mode
         if state >= len(sections):
             state = len(sections) - 1
         lines = sections[state]

--- a/tests/test_glitched_dialog.py
+++ b/tests/test_glitched_dialog.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_dreamer_dialog_normal():
+    result = subprocess.run(
+        CMD,
+        input='cd dream\ncd npc\ntalk dreamer\n1\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert 'dreamer seems stable' in result.stdout
+
+
+def test_dreamer_dialog_glitched():
+    from escape import Game
+
+    expected = Game()._glitch_text(
+        "The dreamer flickers with digital noise.", 2
+    )
+
+    result = subprocess.run(
+        CMD,
+        input='glitch\ncd dream\ncd npc\ntalk dreamer\n1\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    assert expected in result.stdout

--- a/tests/test_validate_dialog.py
+++ b/tests/test_validate_dialog.py
@@ -7,7 +7,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 def test_validate_dialog(tmp_path):
     good = tmp_path / "good.dialog"
-    good.write_text("Hello\n> Continue [flag]\n?flag: done\n")
+    good.write_text("Hello\n> Continue [glitched]\n?glitched: done\n")
 
     bad = tmp_path / "bad.dialog"
     bad.write_text("Oops\n> Broken [flag\n?missing colon\n")


### PR DESCRIPTION
## Summary
- flag NPC conversations with `glitched` when glitch mode is active
- add conditional glitched lines for the Dreamer
- update dialog validator test for the new flag
- add tests verifying dialog changes with glitch mode

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d76acb48832a919439318db7195a