### PR TITLE
Add puzzle plugin

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -73,3 +73,6 @@ Running one of these commands sets ``game.dir_color`` and ``game.item_color`` to
 predefined ANSI codes.
 
 
+## Built-in Puzzle Plugin
+
+A second bundled plugin named `puzzle.py` offers a small code-breaking riddle. Run `puzzle` without arguments to see the encoded phrase and pass your decoded answer to solve it. The module remembers if you solved the puzzle so subsequent runs simply report that it is already complete.

--- a/escape/plugins/puzzle.py
+++ b/escape/plugins/puzzle.py
@@ -1,0 +1,24 @@
+puzzle_solved = False
+
+_encoded_msg = "Uifsf jt b tfdsfu nfttbhf."
+_answer = "there is a secret message."
+
+def puzzle(arg: str = "") -> None:
+    """Small code-breaking challenge."""
+    global puzzle_solved
+    if puzzle_solved:
+        game._output("Puzzle already solved.")
+        return
+    guess = arg.strip().lower()
+    if not guess:
+        game._output(f"Decode this: {_encoded_msg}")
+        return
+    if guess == _answer:
+        puzzle_solved = True
+        game._output("Correct! Puzzle solved.")
+    else:
+        game._output("Incorrect. Try again.")
+
+
+if 'game' in globals():
+    game.command_map['puzzle'] = lambda arg="": puzzle(arg)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -109,3 +109,17 @@ def test_theme_plugin(monkeypatch, capsys):
     game.run()
     assert game.dir_color == '\x1b[92m'
     assert game.item_color == '\x1b[95m'
+
+
+def test_puzzle_plugin(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'puzzle',
+        'puzzle There is a secret message.',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out_lines = capsys.readouterr().out.splitlines()
+    assert any('Decode this:' in line for line in out_lines)
+    assert 'Correct! Puzzle solved.' in out_lines


### PR DESCRIPTION
## Summary
- add new built-in plugin `puzzle` with a simple riddle
- document the puzzle plugin
- test puzzle plugin discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855de9e2278832a8e85333e833fa2ac