### PR TITLE
Add reality directory and new log items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,6 @@ cython_debug/
 !data/node.log
 !data/deep.node.log
 !data/runtime.log
+!data/mirror.log
+!data/truth.log
 data/logs/

--- a/escape/data/mirror.log
+++ b/escape/data/mirror.log
@@ -1,0 +1,1 @@
+The screen acts like a mirror, revealing fragments of your true self.

--- a/escape/data/truth.log
+++ b/escape/data/truth.log
@@ -1,0 +1,1 @@
+Truth scrolls across the display, unfiltered and absolute.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -82,6 +82,14 @@
         "desc": "Connections pulse faintly in this virtual mesh.",
         "items": [],
         "dirs": {}
+      },
+      "reality": {
+        "desc": "A stark directory reflecting the system's underlying truths.",
+        "items": [
+          "mirror.log",
+          "truth.log"
+        ],
+        "dirs": {}
       }
     }
   },
@@ -198,7 +206,9 @@
     "hypervisor.command": "A privileged command set for manipulating the hypervisor.",
     "quantum.access": "An advanced key enabling entry to quantum subsystems.",
     "runtime.log": "A record detailing your own execution environment.",
-    "dream.index": "A fused log bridging memory and dream."
+    "dream.index": "A fused log bridging memory and dream.",
+    "mirror.log": "A log that reflects your actions with unsettling clarity.",
+    "truth.log": "A blunt record exposing the system's true nature."
   },
   "recipes": {
     "flashback.log+reverie.log": "dream.index"

--- a/tests/test_reality_dir.py
+++ b/tests/test_reality_dir.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_reality_directory_and_files():
+    result = subprocess.run(
+        CMD,
+        input='ls\ncd reality\nls\ncat mirror.log\ncat truth.log\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'reality/' in out
+    assert 'mirror.log' in out
+    assert 'truth.log' in out
+    assert 'fragments of your true self' in out
+    assert 'unfiltered and absolute' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- expand `world.json` with a `reality` directory
- describe new `mirror.log` and `truth.log` items
- include placeholder narrative logs
- keep `.gitignore` from ignoring the new logs
- test that `reality/` and its files work

## Testing
- `pip install -e .[test]`
- `pytest -q`
- `pytest -q tests/test_reality_dir.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6855e7281e8c832aa38b8a4f7086e609