### PR TITLE
Add mentor NPC and regression test

### DIFF
--- a/escape/data/npc/mentor.dialog
+++ b/escape/data/npc/mentor.dialog
@@ -1,0 +1,18 @@
+The mentor studies you from behind a screen of scrolling code.
+> Request training [+respect]
+> Question the mentor's methods [-respect]
+> Leave
+"Focus is the foundation of mastery."
+---
+?respect:The mentor nods approvingly at your dedication.
+?!respect:The mentor's eyes narrow at your defiance.
+> Ask about advanced techniques [+curious]
+> Step away
+"Practice turns knowledge into skill."
+---
+?curious:The mentor shares a final tip before returning to work.
+> Thank the mentor [+gratitude]
+> Depart
+"Use these lessons wisely."
+---
+?gratitude:The mentor smiles, already lost in their thoughts.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -176,6 +176,10 @@
     "archivist": [
       "memory",
       "npc"
+    ],
+    "mentor": [
+      "core",
+      "npc"
     ]
   },
   "item_descriptions": {

--- a/tests/test_npc_mentor.py
+++ b/tests/test_npc_mentor.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_mentor_first_and_second_stage():
+    result = subprocess.run(
+        CMD,
+        input='cd core\ncd npc\ntalk mentor\n1\ntalk mentor\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'mentor studies you' in out
+    assert '1. Request training' in out
+    assert 'Focus is the foundation of mastery.' in out
+    assert 'mentor nods approvingly' in out
+    assert 'Practice turns knowledge into skill.' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- create `mentor.dialog` for a new NPC
- place `mentor` in the world map
- test mentor conversation flow

## Testing
- `pytest -q tests/test_npc_mentor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e8a00d34832ab4302072fcdfa2ae