### PR TITLE
Add quest tracking system

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ unexpected ways.
   - `achievements` – list any achievements you've unlocked
   - `man <command>` – show the manual page for a command
   - `journal` – view notes or `journal add <text>` to record a message
+  - `quest` – list quests or `quest add <text>` / `quest complete <id>`
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them
   - `score` – display your current score

--- a/escape/game.py
+++ b/escape/game.py
@@ -74,6 +74,9 @@ class Game:
         # notes recorded by the player
         self.journal: list[str] = []
 
+        # active quests tracked by the player
+        self.quests: list[str] = []
+
         # runtime command aliases created via the 'alias' command
         self.aliases: dict[str, str] = {}
 
@@ -109,6 +112,7 @@ class Game:
             "prompt": "Change or display the input prompt",
             "history": "Show command history",
             "journal": "View or add personal notes",
+            "quest": "List, add or complete quests",
             "sleep": "Enter the dream state and rest",
             "score": "Show your current score",
             "achievements": "List unlocked achievements",
@@ -150,6 +154,7 @@ class Game:
             "prompt": lambda arg="": self._prompt(arg),
             "history": lambda arg="": self._history(),
             "journal": lambda arg="": self._journal(arg),
+            "quest": lambda arg="": self._quest(arg),
             "sleep": lambda arg="": self._sleep(arg),
             "score": lambda arg="": self._score(),
             "achievements": lambda arg="": self._achievements(),
@@ -974,6 +979,7 @@ class Game:
             "aliases": self.aliases,
             "command_history": self.command_history,
             "journal": self.journal,
+            "quests": self.quests,
             "score": self.score,
             "achievements": self.achievements,
         }
@@ -1011,6 +1017,7 @@ class Game:
         self.aliases = data.get("aliases", {})
         self.command_history = data.get("command_history", [])
         self.journal = data.get("journal", [])
+        self.quests = data.get("quests", [])
         self.score = data.get("score", 0)
         self.achievements = data.get("achievements", [])
         self._output("Game loaded.")
@@ -1042,6 +1049,46 @@ class Game:
             self._output("Note added.")
         else:
             self._output("Usage: journal [add <text>]")
+
+    def _quest(self, arg: str = "") -> None:
+        """List current quests or modify the quest list."""
+        arg = arg.strip()
+        if not arg:
+            if not self.quests:
+                self._output("No quests.")
+            else:
+                for idx, q in enumerate(self.quests, 1):
+                    self._output(f"{idx}. {q}")
+            return
+        lower = arg.lower()
+        if lower.startswith("add "):
+            text = arg[4:].strip()
+            if not text:
+                self._output("Usage: quest add <text>")
+                return
+            self.quests.append(text)
+            self._output("Quest added.")
+        elif lower.startswith("complete "):
+            target = arg[9:].strip()
+            if not target:
+                self._output("Usage: quest complete <num|text>")
+                return
+            done = False
+            if target.isdigit():
+                idx = int(target) - 1
+                if 0 <= idx < len(self.quests):
+                    self.quests.pop(idx)
+                    done = True
+            else:
+                if target in self.quests:
+                    self.quests.remove(target)
+                    done = True
+            if done:
+                self._output("Quest completed.")
+            else:
+                self._output("No such quest.")
+        else:
+            self._output("Usage: quest [add <text>|complete <num|text>]")
 
     def _alias(self, arg: str) -> None:
         """Create a new alias or list existing aliases."""

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -1,0 +1,26 @@
+from escape import Game
+
+
+def test_quest_add_and_list(capsys):
+    game = Game()
+    game._quest("add find treasure")
+    game._quest("add talk to mentor")
+    out = capsys.readouterr().out
+    assert out.count("Quest added.") == 2
+    game._quest()
+    out = capsys.readouterr().out
+    assert "1. find treasure" in out
+    assert "2. talk to mentor" in out
+
+
+def test_quest_persistence(tmp_path):
+    game = Game()
+    game.save_file = tmp_path / "game.sav"
+    game._quest("add escape the terminal")
+    game._save()
+
+    new_game = Game()
+    new_game.save_file = game.save_file
+    new_game._load()
+    assert new_game.quests == ["escape the terminal"]
+


### PR DESCRIPTION
## Summary
- implement quest persistence in `Game`
- add `quest` command for listing, adding and completing quests
- document the new command in README
- test quest functionality and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855eb18aefc832aa8798178987bd19a