### PR TITLE
Add custom color codes to theme plugin

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -67,10 +67,13 @@ changing the highlight colors at runtime.
 theme dark   # blue directories, magenta items
 theme mono   # monochrome output
 theme neon   # bright green directories and magenta items
+theme 32 35  # use custom ANSI codes
 ```
 
 Running one of these commands sets ``game.dir_color`` and ``game.item_color`` to
-predefined ANSI codes.
+predefined or custom ANSI codes. When the argument does not match a preset,
+provide two color codes (as numbers understood by the terminal) to set the
+directory and item colors explicitly.
 
 
 ## Built-in Puzzle Plugin

--- a/escape/plugins/theme.py
+++ b/escape/plugins/theme.py
@@ -1,3 +1,6 @@
+import re
+
+
 THEMES = {
     'dark': ("\x1b[34m", "\x1b[35m"),  # blue directories, magenta items
     'mono': ("\x1b[37m", "\x1b[37m"),  # white directories and items
@@ -5,14 +8,33 @@ THEMES = {
 }
 
 
+def _valid_code(code: str) -> bool:
+    """Return True if ``code`` looks like an ANSI color number list."""
+    return bool(re.fullmatch(r"\d+(;\d+)*", code))
+
+
 def theme(arg: str = "") -> None:
-    """Switch between predefined color themes."""
-    name = arg.strip().lower()
-    if name not in THEMES:
-        game._output("Usage: theme [dark|mono|neon]")
+    """Switch between predefined color themes or set custom codes."""
+    text = arg.strip()
+    if not text:
+        game._output("Usage: theme [dark|mono|neon|<dir> <item>]")
         return
-    game.dir_color, game.item_color = THEMES[name]
-    game._output(f"Theme set to {name}.")
+
+    tokens = text.split()
+    name = tokens[0].lower()
+    if name in THEMES and len(tokens) == 1:
+        game.dir_color, game.item_color = THEMES[name]
+        game._output(f"Theme set to {name}.")
+        return
+
+    if len(tokens) != 2 or not all(_valid_code(t) for t in tokens):
+        game._output("Usage: theme [dark|mono|neon|<dir> <item>]")
+        return
+
+    dir_code, item_code = tokens
+    game.dir_color = f"\x1b[{dir_code}m"
+    game.item_color = f"\x1b[{item_code}m"
+    game._output("Theme set to custom.")
 
 
 if 'game' in globals():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -111,6 +111,15 @@ def test_theme_plugin(monkeypatch, capsys):
     assert game.item_color == '\x1b[95m'
 
 
+def test_theme_plugin_custom_codes(monkeypatch, capsys):
+    game = Game()
+    inputs = iter(['theme 32 31', 'quit'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    assert game.dir_color == '\x1b[32m'
+    assert game.item_color == '\x1b[31m'
+
+
 def test_puzzle_plugin(monkeypatch, capsys):
     game = Game()
     inputs = iter([


### PR DESCRIPTION
## Summary
- enhance theme plugin to parse custom dir/item color codes
- validate numeric codes and apply to game colors
- document new theme usage
- test custom color handling

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ec569cdc832aa7aa1c8b22d00903