### PR TITLE
Add manuals for every command

### DIFF
--- a/escape/data/man/achievements.man
+++ b/escape/data/man/achievements.man
@@ -1,0 +1,3 @@
+achievements - List unlocked achievements
+Usage: achievements
+Example: achievements

--- a/escape/data/man/alias.man
+++ b/escape/data/man/alias.man
@@ -1,0 +1,3 @@
+alias - Create command shortcuts
+Usage: alias <name> <command>
+Example: alias l look

--- a/escape/data/man/cat.man
+++ b/escape/data/man/cat.man
@@ -1,0 +1,3 @@
+cat - Display the contents of a file
+Usage: cat <file>
+Example: cat daemon.log

--- a/escape/data/man/cd.man
+++ b/escape/data/man/cd.man
@@ -1,0 +1,3 @@
+cd - Change directory
+Usage: cd <dir>
+Example: cd dream

--- a/escape/data/man/color.man
+++ b/escape/data/man/color.man
@@ -1,0 +1,3 @@
+color - Toggle ANSI color output
+Usage: color [on|off|toggle]
+Example: color toggle

--- a/escape/data/man/combine.man
+++ b/escape/data/man/combine.man
@@ -1,0 +1,3 @@
+combine - Combine two items if a recipe matches
+Usage: combine <item1> <item2>
+Example: combine item1 item2

--- a/escape/data/man/decode.man
+++ b/escape/data/man/decode.man
@@ -1,0 +1,3 @@
+decode - Decode the mem.fragment
+Usage: decode mem.fragment
+Example: decode mem.fragment

--- a/escape/data/man/drop.man
+++ b/escape/data/man/drop.man
@@ -1,0 +1,3 @@
+drop - Remove an item from your inventory
+Usage: drop <item>
+Example: drop decoder

--- a/escape/data/man/examine.man
+++ b/escape/data/man/examine.man
@@ -1,0 +1,3 @@
+examine - Examine an item in detail
+Usage: examine <item>
+Example: examine decoder

--- a/escape/data/man/glitch.man
+++ b/escape/data/man/glitch.man
@@ -1,0 +1,3 @@
+glitch - Toggle glitch mode
+Usage: glitch
+Example: glitch

--- a/escape/data/man/grep.man
+++ b/escape/data/man/grep.man
@@ -1,0 +1,3 @@
+grep - Search log files for text
+Usage: grep <pattern> [file]
+Example: grep error daemon.log

--- a/escape/data/man/hack.man
+++ b/escape/data/man/hack.man
@@ -1,0 +1,3 @@
+hack - Attempt to unlock a node
+Usage: hack <dir>
+Example: hack node

--- a/escape/data/man/help.man
+++ b/escape/data/man/help.man
@@ -1,0 +1,3 @@
+help - Show help for commands
+Usage: help [command]
+Example: help look

--- a/escape/data/man/history.man
+++ b/escape/data/man/history.man
@@ -1,0 +1,3 @@
+history - Show command history
+Usage: history
+Example: history

--- a/escape/data/man/inventory.man
+++ b/escape/data/man/inventory.man
@@ -1,0 +1,3 @@
+inventory - List inventory contents
+Usage: inventory
+Example: inventory

--- a/escape/data/man/journal.man
+++ b/escape/data/man/journal.man
@@ -1,0 +1,3 @@
+journal - View or add personal notes
+Usage: journal [add <text>]
+Example: journal add Remember this

--- a/escape/data/man/load.man
+++ b/escape/data/man/load.man
@@ -1,0 +1,3 @@
+load - Load a saved game
+Usage: load [slot]
+Example: load 1

--- a/escape/data/man/look.man
+++ b/escape/data/man/look.man
@@ -1,2 +1,4 @@
 look - describe the current room or a subdirectory
 Usage: look [dir] or look around
+Example: look hidden
+

--- a/escape/data/man/ls.man
+++ b/escape/data/man/ls.man
@@ -1,2 +1,4 @@
 ls - list items and subdirectories in the current directory
 Usage: ls
+Example: ls
+

--- a/escape/data/man/man.man
+++ b/escape/data/man/man.man
@@ -1,0 +1,3 @@
+man - Show a manual page for a command
+Usage: man <command>
+Example: man ls

--- a/escape/data/man/map.man
+++ b/escape/data/man/map.man
@@ -1,0 +1,3 @@
+map - Display the directory tree
+Usage: map
+Example: map

--- a/escape/data/man/prompt.man
+++ b/escape/data/man/prompt.man
@@ -1,0 +1,3 @@
+prompt - Change or display the input prompt
+Usage: prompt [text]
+Example: prompt >

--- a/escape/data/man/pwd.man
+++ b/escape/data/man/pwd.man
@@ -1,0 +1,3 @@
+pwd - Show current path
+Usage: pwd
+Example: pwd

--- a/escape/data/man/quest.man
+++ b/escape/data/man/quest.man
@@ -1,0 +1,3 @@
+quest - List, add or complete quests
+Usage: quest [add <text>|complete <num|text>]
+Example: quest add escape

--- a/escape/data/man/quit.man
+++ b/escape/data/man/quit.man
@@ -1,0 +1,3 @@
+quit - Exit the game
+Usage: quit
+Example: quit

--- a/escape/data/man/restart.man
+++ b/escape/data/man/restart.man
@@ -1,0 +1,3 @@
+restart - Restart the game
+Usage: restart
+Example: restart

--- a/escape/data/man/save.man
+++ b/escape/data/man/save.man
@@ -1,0 +1,3 @@
+save - Save game state
+Usage: save [slot]
+Example: save 1

--- a/escape/data/man/scan.man
+++ b/escape/data/man/scan.man
@@ -1,0 +1,3 @@
+scan - Scan a directory for hidden nodes
+Usage: scan <dir>
+Example: scan network

--- a/escape/data/man/score.man
+++ b/escape/data/man/score.man
@@ -1,0 +1,3 @@
+score - Show your current score
+Usage: score
+Example: score

--- a/escape/data/man/sleep.man
+++ b/escape/data/man/sleep.man
@@ -1,0 +1,3 @@
+sleep - Enter the dream state and rest
+Usage: sleep [reset|inc]
+Example: sleep

--- a/escape/data/man/take.man
+++ b/escape/data/man/take.man
@@ -1,0 +1,3 @@
+take - Add an item to your inventory
+Usage: take <item>
+Example: take decoder

--- a/escape/data/man/talk.man
+++ b/escape/data/man/talk.man
@@ -1,0 +1,3 @@
+talk - Speak with an NPC
+Usage: talk <npc>
+Example: talk mentor

--- a/escape/data/man/unalias.man
+++ b/escape/data/man/unalias.man
@@ -1,0 +1,3 @@
+unalias - Remove a command alias
+Usage: unalias <name>
+Example: unalias l

--- a/escape/data/man/use.man
+++ b/escape/data/man/use.man
@@ -1,0 +1,3 @@
+use - Use an item, optionally on a target
+Usage: use <item> [on <target>]
+Example: use access.key

--- a/tests/test_help_all_commands.py
+++ b/tests/test_help_all_commands.py
@@ -1,10 +1,14 @@
 import pytest
+from pathlib import Path
+
 from escape import Game
 
 
 def test_help_for_each_command(capsys):
     game = Game()
+    man_dir = Path(game.data_dir) / "man"
     for cmd, desc in game.command_descriptions.items():
         game._print_help(cmd)
         out = capsys.readouterr().out
         assert f"{cmd}: {desc}" in out
+        assert (man_dir / f"{cmd}.man").exists()


### PR DESCRIPTION
## Summary
- document every command with a `.man` file including usage and example
- verify that each command has a manual entry in `test_help_all_commands`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ed1f4a28832ab11597d378370358