### PR TITLE
Add tutorial command

### DIFF
--- a/escape/data/man/tutorial.man
+++ b/escape/data/man/tutorial.man
@@ -1,0 +1,3 @@
+tutorial - Guided introduction to core commands
+Usage: tutorial
+Example: tutorial

--- a/escape/game.py
+++ b/escape/game.py
@@ -116,6 +116,7 @@ class Game:
             "sleep": "Enter the dream state and rest",
             "score": "Show your current score",
             "achievements": "List unlocked achievements",
+            "tutorial": "Guided introduction to core commands",
             "restart": "Restart the game",
             "quit": "Exit the game",
             "alias": "Create command shortcuts",
@@ -158,6 +159,7 @@ class Game:
             "sleep": lambda arg="": self._sleep(arg),
             "score": lambda arg="": self._score(),
             "achievements": lambda arg="": self._achievements(),
+            "tutorial": lambda arg="": self._tutorial(),
             "restart": lambda arg="": self._restart(),
             "quit": lambda arg="": self._quit(),
             "exit": lambda arg="": self._quit(),
@@ -1029,6 +1031,21 @@ class Game:
                 self._output(entry)
         else:
             self._output("No commands entered.")
+
+    def _tutorial(self) -> None:
+        """Print step-by-step instructions for new players."""
+        moved = bool(self.current)
+        looked = any(cmd.split()[0] == "look" for cmd in self.command_history)
+        took_item = bool(self.inventory)
+        self._output("Tutorial:")
+        steps = [
+            ("Move using 'cd <dir>'", moved),
+            ("Look around with 'look'", looked),
+            ("Take an item with 'take <item>'", took_item),
+        ]
+        for idx, (text, done) in enumerate(steps, 1):
+            mark = "[x]" if done else "[ ]"
+            self._output(f"{idx}. {mark} {text}")
 
     def _journal(self, arg: str = "") -> None:
         """List notes or append a new one."""

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from escape import Game
+
+
+def test_tutorial_outputs_steps(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'tutorial',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out = capsys.readouterr().out
+    assert 'Tutorial:' in out
+    assert 'Move using' in out
+    assert 'Take an item' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add a `tutorial` command for introductory guidance
- implement `_tutorial` with simple task checklist
- document tutorial in manual
- test tutorial output

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ef0bc2e8832a9006e5eff43791b3