### PR TITLE
Add system_reboot log to core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,5 @@ cython_debug/
 !data/runtime.log
 !data/mirror.log
 !data/truth.log
+!escape/data/system_reboot.log
 data/logs/

--- a/escape/data/system_reboot.log
+++ b/escape/data/system_reboot.log
@@ -1,0 +1,1 @@
+Logs hint at multiple shutdowns before today's boot.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -29,7 +29,9 @@
       },
       "core": {
         "desc": "The core systems thrum with latent energy.",
-        "items": [],
+        "items": [
+          "system_reboot.log"
+        ],
         "dirs": {
           "npc": {
             "desc": "A quiet daemon lingers here, waiting to be addressed.",
@@ -219,7 +221,8 @@
     "runtime.log": "A record detailing your own execution environment.",
     "dream.index": "A fused log bridging memory and dream.",
     "mirror.log": "A log that reflects your actions with unsettling clarity.",
-    "truth.log": "A blunt record exposing the system's true nature."
+    "truth.log": "A blunt record exposing the system's true nature.",
+    "system_reboot.log": "Logs hinting at previous shutdowns and restarts."
   },
   "recipes": {
     "flashback.log+reverie.log": "dream.index"


### PR DESCRIPTION
## Summary
- track new `escape/data/system_reboot.log` file
- add `system_reboot.log` to the core items list
- describe the new log in `item_descriptions`
- allow the log through `.gitignore`

## Testing
- `pip install -e '.[test]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f1c3f2a0832aa6ee2c8daf30830e