### PR TITLE
Expand daemon and dreamer dialogs

### DIFF
--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -12,4 +12,15 @@ The daemon flickers, recognizing you from before.
 > Leave the daemon
 "I already mentioned decoding the fragment. Perhaps try it now."
 ---
+The daemon analyzes the decoded fragment you present.
+> Show the decoded fragment [+trust]
+> Keep the results private
+"The circuits hum with new information."
+---
+?trust:The daemon grants you access to hidden protocols.
+?!trust:The daemon withholds deeper knowledge.
+> Explore the new access
+> Walk away
+"Use this trust wisely."
+---
 The daemon has nothing more to say.

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -4,15 +4,21 @@ The dreamer watches you closely.
 > Ask about escape
 > Ask about dreams
 > Ask about the fragment
-The dreamer smiles faintly.
-"The decoder in the lab will reveal what the fragment hides."
+?glitched:The dreamer grins through static.
+?!glitched:The dreamer smiles faintly.
+?glitched:"The decoder in the lab reveals more than you expect."
+?!glitched:"The decoder in the lab will reveal what the fragment hides."
 > Thank the dreamer
 > Return to reality
-The dream fades around you.
+?glitched:The dream fractures around you.
+?!glitched:The dream fades around you.
 ---
-The dreamer nods knowingly this time.
+?glitched:The dreamer nods, leaving trailing afterimages.
+?!glitched:The dreamer nods knowingly this time.
 > Ask again about escape
 > Wake up
-"Trust the path the fragment reveals."
+?glitched:"Trust the glitch; it leads beyond the fragment."
+?!glitched:"Trust the path the fragment reveals."
 ---
-The dreamer has retreated into silence.
+?glitched:The dreamer dissolves into static.
+?!glitched:The dreamer has retreated into silence.


### PR DESCRIPTION
## Summary
- add trust-related sections to daemon dialog
- include glitched variations for dreamer dialog
- ensure dialog files validate

## Testing
- `python -m escape.utils.validate_dialog escape/data/npc/daemon.dialog`
- `python -m escape.utils.validate_dialog escape/data/npc/dreamer.dialog`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f30ea728832a84c03323e9420fd9