### PR TITLE
Add memory_bridge area and update combine behavior

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -64,6 +64,11 @@
             "desc": "An enigmatic chamber humming with distant voices.",
             "items": [],
             "dirs": {}
+          },
+          "memory_bridge": {
+            "desc": "A shimmering path bridging memory and dream.",
+            "items": [],
+            "dirs": {}
           }
         }
       },

--- a/escape/game.py
+++ b/escape/game.py
@@ -1175,6 +1175,18 @@ class Game:
         self.inventory.remove(item2)
         self.inventory.append(result)
         self._output(f"You combine {item1} and {item2} into {result}.")
+        if result == "dream.index":
+            dream_dirs = (
+                self.fs.setdefault("dirs", {})
+                .setdefault("dream", {})
+                .setdefault("dirs", {})
+            )
+            if "memory_bridge" not in dream_dirs:
+                dream_dirs["memory_bridge"] = {
+                    "desc": "A shimmering path bridging memory and dream.",
+                    "items": ["dream.index"],
+                    "dirs": {},
+                }
 
     def _sleep(self, arg: str = "") -> None:
         """Enter the dream directory and optionally modify glitch intensity."""

--- a/tests/test_combine_command.py
+++ b/tests/test_combine_command.py
@@ -19,6 +19,7 @@ def test_combine_valid_items(capsys):
     assert 'dream.index' in game.inventory
     assert 'flashback.log' not in game.inventory
     assert 'reverie.log' not in game.inventory
+    assert 'memory_bridge' in game.fs['dirs']['dream']['dirs']
 
 
 def test_combine_invalid_recipe(capsys):


### PR DESCRIPTION
## Summary
- bridge memory and dream when crafting `dream.index`
- describe new `memory_bridge` location
- test for new directory after combining items

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f74b1b5c832a8bda4bd962a48701