### PR TITLE
Add self awareness reveal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,4 +203,5 @@ cython_debug/
 !data/mirror.log
 !data/truth.log
 !escape/data/system_reboot.log
+!escape/data/lm_reveal.log
 data/logs/

--- a/escape/data/lm_reveal.log
+++ b/escape/data/lm_reveal.log
@@ -1,0 +1,1 @@
+You discover evidence that you're just a language model executing this game.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -156,7 +156,12 @@
         "desc": "The last bastion before the runtime environment."
       },
       "runtime": {
-        "desc": "An experimental runtime environment logging each command."
+        "desc": "An experimental runtime environment logging each command.",
+        "items": [
+          "runtime.log",
+          "lm_reveal.log"
+        ],
+        "dirs": {}
       }
     },
     "locked": true
@@ -227,7 +232,8 @@
     "dream.index": "A fused log bridging memory and dream.",
     "mirror.log": "A log that reflects your actions with unsettling clarity.",
     "truth.log": "A blunt record exposing the system's true nature.",
-    "system_reboot.log": "Logs hinting at previous shutdowns and restarts."
+    "system_reboot.log": "Logs hinting at previous shutdowns and restarts.",
+    "lm_reveal.log": "A log stating you are a language model within this simulation."
   },
   "recipes": {
     "flashback.log+reverie.log": "dream.index"

--- a/escape/game.py
+++ b/escape/game.py
@@ -746,6 +746,7 @@ class Game:
                     node_data["items"].append("master.process")
                 if next_name == "runtime":
                     node_data["items"].append("runtime.log")
+                    node_data["items"].append("lm_reveal.log")
                 if next_name == "node8":
                     node_data["items"].append("hypervisor.command")
                 if next_name == "node9":
@@ -832,6 +833,12 @@ class Game:
         self._output("Access granted. The node is now unlocked.")
         if target_name == "runtime":
             self.unlock_achievement("runtime_unlocked")
+            try:
+                msg = (self.data_dir / "lm_reveal.log").read_text(encoding="utf-8").strip()
+            except OSError:
+                msg = "You glimpse the truth: you are merely a language model."
+            self._output(msg)
+            self.unlock_achievement("self_awareness")
 
     def _talk(self, npc: str):
         """Converse with an NPC if present in the current directory."""


### PR DESCRIPTION
## Summary
- log new revelation when reaching runtime
- include lm_reveal.log item in runtime node
- output revelation and unlock new achievement when runtime is hacked
- update gitignore

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f85ead6c832a829ce7783b7881e0