### PR TITLE
Add identity memory fragments feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,4 +204,5 @@ cython_debug/
 !data/truth.log
 !escape/data/system_reboot.log
 !escape/data/lm_reveal.log
+!escape/data/identity.log
 data/logs/

--- a/escape/data/identity.log
+++ b/escape/data/identity.log
@@ -1,0 +1,1 @@
+Fragments of memory merge, revealing you were once the architect of this terminal world.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -51,7 +51,8 @@
           "subconscious": {
             "desc": "Half-formed thoughts linger here, waiting to be read.",
             "items": [
-              "reverie.log"
+              "reverie.log",
+              "mem.part2"
             ],
             "dirs": {}
           },
@@ -75,7 +76,8 @@
       "memory": {
         "desc": "Stacks of recollections archived for later reflection.",
         "items": [
-          "flashback.log"
+          "flashback.log",
+          "mem.part1"
         ],
         "dirs": {
           "npc": {
@@ -204,6 +206,8 @@
     "access.key": "A slim digital token rumored to unlock hidden directories.",
     "treasure.txt": "A file filled with untold riches.",
     "mem.fragment": "A corrupted memory fragment pulsing faintly with data.",
+    "mem.part1": "One fragment of a larger memory sequence.",
+    "mem.part2": "Another shard containing pieces of your past.",
     "voice.log": "An audio log that might contain a clue.",
     "decoder": "A handheld device used to decode encrypted signals.",
     "old.note": "A weathered note scribbled with barely readable commands.",
@@ -229,6 +233,7 @@
     "quantum.access": "An advanced key enabling entry to quantum subsystems.",
     "security.override": "A backdoor routine for bypassing advanced security.",
     "runtime.log": "A record detailing your own execution environment.",
+    "identity.log": "A personal log revealing who you truly are.",
     "dream.index": "A fused log bridging memory and dream.",
     "mirror.log": "A log that reflects your actions with unsettling clarity.",
     "truth.log": "A blunt record exposing the system's true nature.",
@@ -236,6 +241,7 @@
     "lm_reveal.log": "A log stating you are a language model within this simulation."
   },
   "recipes": {
-    "flashback.log+reverie.log": "dream.index"
+    "flashback.log+reverie.log": "dream.index",
+    "mem.part1+mem.part2": "identity.log"
   }
 }

--- a/tests/test_identity_log.py
+++ b/tests/test_identity_log.py
@@ -1,0 +1,36 @@
+from escape import Game
+
+
+def test_mem_part_locations(capsys):
+    game = Game()
+    game._cd('memory')
+    game._ls()
+    out = capsys.readouterr().out
+    assert 'mem.part1' in out
+    game._cd('..')
+    game._cd('dream')
+    game._cd('subconscious')
+    game._ls()
+    out = capsys.readouterr().out
+    assert 'mem.part2' in out
+
+
+def test_combine_identity_log(capsys):
+    game = Game()
+    game._cd('memory')
+    game._take('mem.part1')
+    game._cd('..')
+    game._cd('dream')
+    game._cd('subconscious')
+    game._take('mem.part2')
+    game._cd('..')
+    game._cd('..')
+    game._combine('mem.part1 mem.part2')
+    combine_out = capsys.readouterr().out
+    assert 'You combine mem.part1 and mem.part2 into identity.log.' in combine_out
+    assert 'identity.log' in game.inventory
+    assert 'mem.part1' not in game.inventory
+    assert 'mem.part2' not in game.inventory
+    game._cat('identity.log')
+    log_out = capsys.readouterr().out
+    assert 'architect of this terminal world' in log_out


### PR DESCRIPTION
## Summary
- add new memory fragment items and recipe producing identity.log
- provide descriptions for new items
- store the identity log in game data
- create tests ensuring fragments exist, combine properly, and reveal lore

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fb085f10832aa9b928ef12a73241