### PR TITLE
Add dialog flags based on achievements

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -1,4 +1,6 @@
 The archivist catalogues swirling fragments with meticulous precision.
+?decoded:The archivist nods at your decrypted fragment.
+?runtime:The archivist whispers of a hidden runtime.
 > Ask about restoring memories [+curious]
 > Browse the catalog [-curious]
 > Leave

--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -1,4 +1,6 @@
 The daemon acknowledges your presence.
+?decoded:The daemon hums as the fragment's code becomes clear.
+?runtime:The daemon senses your runtime access.
 > Ask about system status
 > Ask about hidden directories
 "Keep your code clean," it drones.

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -1,4 +1,6 @@
 The dreamer watches you closely.
+?decoded:The dreamer remarks on your newfound clarity.
+?runtime:The dreamer hints at a runtime beyond dreams.
 ?glitched:The dreamer flickers with digital noise.
 ?!glitched:The dreamer seems stable.
 > Ask about escape

--- a/escape/data/npc/glitcher.dialog
+++ b/escape/data/npc/glitcher.dialog
@@ -1,4 +1,6 @@
 The glitcher crackles with unstable energy.
+?decoded:The static dims at your accomplishment.
+?runtime:The glitcher vibrates, sensing the runtime breach.
 > Observe
 > Retreat
 "Fragments... fragments everywhere."

--- a/escape/data/npc/mentor.dialog
+++ b/escape/data/npc/mentor.dialog
@@ -1,4 +1,6 @@
 The mentor studies you from behind a screen of scrolling code.
+?decoded:The mentor glances at the decoded data with interest.
+?runtime:The mentor warns you about meddling with the runtime.
 > Request training [+respect]
 > Question the mentor's methods [-respect]
 > Leave

--- a/escape/data/npc/oracle.dialog
+++ b/escape/data/npc/oracle.dialog
@@ -1,4 +1,6 @@
 The oracle hovers in a loop of swirling code.
+?decoded:The oracle senses the fragment has been deciphered.
+?runtime:The oracle murmurs about the unlocked runtime.
 > Seek prophecy [+vision]
 > Walk away [-vision]
 "The fragment only reveals its meaning in dreams."

--- a/escape/data/npc/sage.dialog
+++ b/escape/data/npc/sage.dialog
@@ -1,4 +1,6 @@
 The sage sits quietly among ancient files.
+?decoded:The sage acknowledges your progress with a nod.
+?runtime:The sage contemplates the runtime you uncovered.
 > Seek wisdom [+humble]
 > Demand secrets [-humble]
 > Leave silently

--- a/escape/data/npc/sysop.dialog
+++ b/escape/data/npc/sysop.dialog
@@ -1,4 +1,6 @@
 The sysop glances over from a console.
+?decoded:The sysop comments on the decoded fragment.
+?runtime:The sysop raises an eyebrow at your runtime access.
 > Greet politely [+polite]
 > Demand access [-polite]
 ?polite:The sysop nods at your respect.

--- a/escape/data/npc/wanderer.dialog
+++ b/escape/data/npc/wanderer.dialog
@@ -1,4 +1,6 @@
 A weary wanderer drifts through the data fog.
+?decoded:The wanderer recognizes the clarity in your eyes.
+?runtime:The wanderer speaks of a hidden runtime path.
 > Ask about memories
 > Offer help [+helped]
 > Leave

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,218 +1,219 @@
 import subprocess, sys, os
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from escape import Game
 
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
-CMD = [sys.executable, '-m', 'escape']
+CMD = [sys.executable, "-m", "escape"]
 
 
 def test_quit_command():
     result = subprocess.run(
         CMD,
-        input='quit\n',
+        input="quit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Goodbye' in result.stdout
+    assert "Goodbye" in result.stdout
     assert result.returncode == 0
 
 
 def test_look_command():
     result = subprocess.run(
         CMD,
-        input='look\nquit\n',
+        input="look\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'dimly lit terminal' in result.stdout
-    assert 'access.key' in result.stdout
-    assert 'voice.log' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "dimly lit terminal" in result.stdout
+    assert "access.key" in result.stdout
+    assert "voice.log" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_inventory_empty():
     result = subprocess.run(
         CMD,
-        input='inventory\nquit\n',
+        input="inventory\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Inventory is empty' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "Inventory is empty" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_take_item_and_inventory():
     result = subprocess.run(
         CMD,
-        input='take access.key\ninventory\nquit\n',
+        input="take access.key\ninventory\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'pick up the access.key' in result.stdout
-    assert 'Inventory: access.key' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "pick up the access.key" in result.stdout
+    assert "Inventory: access.key" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_examine_item():
     result = subprocess.run(
         CMD,
-        input='examine access.key\nquit\n',
+        input="examine access.key\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'slim digital token' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "slim digital token" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_examine_missing_item():
     result = subprocess.run(
         CMD,
-        input='examine unknown\nquit\n',
+        input="examine unknown\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'do not have unknown' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "do not have unknown" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_inventory_alias_i():
     result = subprocess.run(
         CMD,
-        input='i\nquit\n',
+        input="i\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Inventory is empty' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "Inventory is empty" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_inventory_alias_inv():
     result = subprocess.run(
         CMD,
-        input='inv\nquit\n',
+        input="inv\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Inventory is empty' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "Inventory is empty" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_look_around_alias():
     result = subprocess.run(
         CMD,
-        input='look around\nquit\n',
+        input="look around\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'dimly lit terminal' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "dimly lit terminal" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_look_specific_directory():
     result = subprocess.run(
         CMD,
-        input='look lab\npwd\nquit\n',
+        input="look lab\npwd\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'cluttered research lab' in out
-    assert '> /' in out
+    assert "cluttered research lab" in out
+    assert "> /" in out
 
 
 def test_help_alias():
     result = subprocess.run(
         CMD,
-        input='h\nquit\n',
+        input="h\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Available commands' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "Available commands" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_help_specific_command():
     result = subprocess.run(
         CMD,
-        input='help look\nquit\n',
+        input="help look\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'look: Describe the current room or a subdirectory' in out
-    assert 'Goodbye' in out
+    assert "look: Describe the current room or a subdirectory" in out
+    assert "Goodbye" in out
 
 
 def test_help_unknown_command():
     result = subprocess.run(
         CMD,
-        input='help unknown\nquit\n',
+        input="help unknown\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
     assert "No help available for 'unknown'" in out
-    assert 'Goodbye' in out
+    assert "Goodbye" in out
 
 
 def test_use_item_missing():
     result = subprocess.run(
         CMD,
-        input='use access.key\nquit\n',
+        input="use access.key\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'do not have access.key' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "do not have access.key" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_use_item_after_take():
     result = subprocess.run(
         CMD,
-        input='take access.key\nuse access.key\nquit\n',
+        input="take access.key\nuse access.key\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'pick up the access.key' in result.stdout
-    assert 'hidden directory flickers' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "pick up the access.key" in result.stdout
+    assert "hidden directory flickers" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_use_item_on_door():
     result = subprocess.run(
         CMD,
-        input='take access.key\nuse access.key on door\nls\nquit\n',
+        input="take access.key\nuse access.key on door\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'hidden directory flickers' in out
-    assert 'hidden/' in out
-    assert 'Goodbye' in out
+    assert "hidden directory flickers" in out
+    assert "hidden/" in out
+    assert "Goodbye" in out
 
 
 def test_drop_item():
     result = subprocess.run(
         CMD,
-        input='take access.key\ndrop access.key\nlook\nquit\n',
+        input="take access.key\ndrop access.key\nlook\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'pick up the access.key' in result.stdout
-    assert 'drop the access.key' in result.stdout
-    assert 'access.key' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "pick up the access.key" in result.stdout
+    assert "drop the access.key" in result.stdout
+    assert "access.key" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_save_and_load(tmp_path):
-    save_file = tmp_path / 'game.sav'
+    save_file = tmp_path / "game.sav"
 
     # take item and save the game
     env = os.environ.copy()
-    env['PYTHONPATH'] = REPO_ROOT
+    env["PYTHONPATH"] = REPO_ROOT
     subprocess.run(
         CMD,
-        input='take access.key\nsave\nquit\n',
+        input="take access.key\nsave\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -223,204 +224,200 @@ def test_save_and_load(tmp_path):
     # load the game and check inventory
     result = subprocess.run(
         CMD,
-        input='load\ninventory\nquit\n',
+        input="load\ninventory\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
         env=env,
     )
-    assert 'Inventory: access.key' in result.stdout
+    assert "Inventory: access.key" in result.stdout
 
 
 def test_ls_and_cd():
     result = subprocess.run(
         CMD,
-        input='ls\ntake access.key\nuse access.key\nls\ncd hidden\nls\ncd ..\nls\nquit\n',
+        input="ls\ntake access.key\nuse access.key\nls\ncd hidden\nls\ncd ..\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
     # first ls should not show hidden, final ones should
-    assert 'hidden/' in out
-    assert 'treasure.txt' in out
-    assert out.count('hidden/') >= 1
-    assert 'Goodbye' in out
+    assert "hidden/" in out
+    assert "treasure.txt" in out
+    assert out.count("hidden/") >= 1
+    assert "Goodbye" in out
 
 
 def test_root_contains_dream_and_memory():
     result = subprocess.run(
         CMD,
-        input='ls\nquit\n',
+        input="ls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'dream/' in out
-    assert 'memory/' in out
-    assert 'Goodbye' in out
+    assert "dream/" in out
+    assert "memory/" in out
+    assert "Goodbye" in out
 
 
 def test_pwd_command():
     result = subprocess.run(
         CMD,
-        input='cd lab\npwd\ncd ..\npwd\nquit\n',
+        input="cd lab\npwd\ncd ..\npwd\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert '> > lab' in out
-    assert '> > /' in out
+    assert "> > lab" in out
+    assert "> > /" in out
 
 
 def test_enter_lab_and_look():
     result = subprocess.run(
         CMD,
-        input='cd lab\nlook\nls\nquit\n',
+        input="cd lab\nlook\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'cluttered research lab' in out
-    assert 'decoder' in out
-    assert 'Goodbye' in out
+    assert "cluttered research lab" in out
+    assert "decoder" in out
+    assert "Goodbye" in out
 
 
 def test_cat_command():
     result = subprocess.run(
         CMD,
-        input='cat voice.log\nquit\n',
+        input="cat voice.log\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'faint digital voice' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "faint digital voice" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_man_look():
     result = subprocess.run(
         CMD,
-        input='man look\nquit\n',
+        input="man look\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'describe the current room' in out
-    assert 'Goodbye' in out
+    assert "describe the current room" in out
+    assert "Goodbye" in out
 
 
 def test_use_voice_log():
     result = subprocess.run(
         CMD,
-        input='take voice.log\nuse voice.log\nquit\n',
+        input="take voice.log\nuse voice.log\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'haunting voice' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "haunting voice" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_cat_daemon_log():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ncat daemon.log\nquit\n',
+        input="cd core\ncd npc\ncat daemon.log\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'daemon monitors your actions' in out
-    assert 'Keep your code clean' in out
-    assert 'Goodbye' in out
+    assert "daemon monitors your actions" in out
+    assert "Keep your code clean" in out
+    assert "Goodbye" in out
 
 
 def test_cat_lucid_note():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncat lucid.note\nquit\n',
+        input="cd dream\ncat lucid.note\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'dreams you may chart' in out
-    assert 'Goodbye' in out
+    assert "dreams you may chart" in out
+    assert "Goodbye" in out
 
 
 def test_cat_flashback_log():
     result = subprocess.run(
         CMD,
-        input='cd memory\ncat flashback.log\nquit\n',
+        input="cd memory\ncat flashback.log\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'old memories scroll' in out
-    assert 'Goodbye' in out
+    assert "old memories scroll" in out
+    assert "Goodbye" in out
 
 
 def test_use_daemon_log():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ntake daemon.log\nuse daemon.log\nquit\n',
+        input="cd core\ncd npc\ntake daemon.log\nuse daemon.log\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'pick up the daemon.log' in out
-    assert 'Keep your code clean' in out
-    assert 'Goodbye' in out
+    assert "pick up the daemon.log" in out
+    assert "Keep your code clean" in out
+    assert "Goodbye" in out
 
 
 def test_examine_mem_fragment():
     result = subprocess.run(
         CMD,
-        input='take access.key\nuse access.key\ncd hidden\nexamine mem.fragment\nquit\n',
+        input="take access.key\nuse access.key\ncd hidden\nexamine mem.fragment\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'corrupted memory fragment' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "corrupted memory fragment" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_cat_treasure_after_unlock():
     result = subprocess.run(
         CMD,
-        input='take access.key\nuse access.key\ncd hidden\ncat treasure.txt\nquit\n',
+        input="take access.key\nuse access.key\ncd hidden\ncat treasure.txt\nquit\n",
         text=True,
         capture_output=True,
     )
     assert (
-        'You discover a stash of credits and a map leading out of the terminal.'
+        "You discover a stash of credits and a map leading out of the terminal."
         in result.stdout
     )
-    assert 'Goodbye' in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_glitch_mode_toggle():
-    normal = (
-        'You find yourself in a dimly lit terminal session. The prompt blinks patiently.'
-    )
+    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
     first_glitch = Game()._glitch_text(normal, 1)
     result = subprocess.run(
         CMD,
-        input='glitch\nlook\nglitch\nlook\nquit\n',
+        input="glitch\nlook\nglitch\nlook\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'Glitch mode activated.' in out
+    assert "Glitch mode activated." in out
     assert first_glitch in out
-    assert 'Glitch mode deactivated.' in out
+    assert "Glitch mode deactivated." in out
     assert normal in out
 
 
 def test_glitch_persistence():
-    normal = (
-        'You find yourself in a dimly lit terminal session. The prompt blinks patiently.'
-    )
+    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
     first_glitch = Game()._glitch_text(normal, 1)
     later_glitch = Game()._glitch_text(normal, 3)
     result = subprocess.run(
         CMD,
-        input='glitch\nlook\nlook\nglitch\nlook\nquit\n',
+        input="glitch\nlook\nlook\nglitch\nlook\nquit\n",
         text=True,
         capture_output=True,
     )
@@ -428,19 +425,17 @@ def test_glitch_persistence():
     assert first_glitch in out
     assert later_glitch in out
     # final look after glitch off should be normal
-    assert out.strip().endswith('Goodbye')
+    assert out.strip().endswith("Goodbye")
 
 
 def test_glitch_intensity_increases():
-    normal = (
-        'You find yourself in a dimly lit terminal session. The prompt blinks patiently.'
-    )
+    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
     step1 = Game()._glitch_text(normal, 1)
     step3 = Game()._glitch_text(normal, 3)
     step5 = Game()._glitch_text(normal, 5)
     result = subprocess.run(
         CMD,
-        input='glitch\nlook\nlook\nlook\nquit\n',
+        input="glitch\nlook\nlook\nlook\nquit\n",
         text=True,
         capture_output=True,
     )
@@ -455,122 +450,150 @@ def test_glitch_intensity_increases():
 def test_talk_daemon():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ntalk daemon\n1\n1\nquit\n',
+        input="cd core\ncd npc\ntalk daemon\n1\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'acknowledges your presence' in out
-    assert '1. Ask about system status' in out
-    assert '1. Request a hint' in out
-    assert 'Decoding the fragment might reveal an escape path' in out
-    assert 'Goodbye' in out
+    assert "acknowledges your presence" in out
+    assert "1. Ask about system status" in out
+    assert "1. Request a hint" in out
+    assert "Decoding the fragment might reveal an escape path" in out
+    assert "Goodbye" in out
 
 
 def test_talk_dreamer():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd npc\ntalk dreamer\n1\n2\nquit\n',
+        input="cd dream\ncd npc\ntalk dreamer\n1\n2\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'dreamer watches you' in out
-    assert '1. Ask about escape' in out
-    assert '3. Ask about the fragment' in out
-    assert 'Ask about escape' in out
-    assert 'The decoder in the lab will reveal what the fragment hides.' in out
-    assert 'Goodbye' in out
+    assert "dreamer watches you" in out
+    assert "1. Ask about escape" in out
+    assert "3. Ask about the fragment" in out
+    assert "Ask about escape" in out
+    assert "The decoder in the lab will reveal what the fragment hides." in out
+    assert "Goodbye" in out
 
 
 def test_dream_contains_subconscious():
     result = subprocess.run(
         CMD,
-        input='cd dream\nls\nquit\n',
+        input="cd dream\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'subconscious/' in out
-    assert 'Goodbye' in out
+    assert "subconscious/" in out
+    assert "Goodbye" in out
 
 
 def test_reverie_log_present():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd subconscious\nls\nquit\n',
+        input="cd dream\ncd subconscious\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'reverie.log' in out
-    assert 'Goodbye' in out
+    assert "reverie.log" in out
+    assert "Goodbye" in out
 
 
 def test_hidden_vault_and_escape_plan():
     result = subprocess.run(
         CMD,
-        input='take access.key\nuse access.key\ncd hidden\nls\ncd vault\nls\nquit\n',
+        input="take access.key\nuse access.key\ncd hidden\nls\ncd vault\nls\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'vault/' in out
-    assert 'escape.plan' in out
-    assert 'Goodbye' in out
+    assert "vault/" in out
+    assert "escape.plan" in out
+    assert "Goodbye" in out
 
 
 def test_decode_fragment_unlocks_escape_directory():
     result = subprocess.run(
         CMD,
         input=(
-            'take access.key\n'
-            'use access.key\n'
-            'cd hidden\n'
-            'take mem.fragment\n'
-            'cd ..\n'
-            'cd lab\n'
-            'take decoder\n'
-            'decode mem.fragment\n'
-            'cd ..\n'
-            'cd hidden\n'
-            'cd vault\n'
-            'ls\n'
-            'quit\n'
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd hidden\n"
+            "cd vault\n"
+            "ls\n"
+            "quit\n"
         ),
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'escape/' in out
-    assert 'Goodbye' in out
+    assert "escape/" in out
+    assert "Goodbye" in out
+
+
+def test_talk_daemon_after_decoding():
+    result = subprocess.run(
+        CMD,
+        input=(
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd core\n"
+            "cd npc\n"
+            "talk daemon\n"
+            "1\n"
+            "2\n"
+            "quit\n"
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert "hums as the fragment's code becomes clear" in out
+    assert "Goodbye" in out
 
 
 def test_use_escape_code_wins_game():
     result = subprocess.run(
         CMD,
         input=(
-            'take access.key\n'
-            'use access.key\n'
-            'cd hidden\n'
-            'take mem.fragment\n'
-            'cd ..\n'
-            'cd lab\n'
-            'take decoder\n'
-            'decode mem.fragment\n'
-            'cd ..\n'
-            'cd hidden\n'
-            'cd vault\n'
-            'cd escape\n'
-            'take escape.code\n'
-            'use escape.code\n'
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd hidden\n"
+            "cd vault\n"
+            "cd escape\n"
+            "take escape.code\n"
+            "use escape.code\n"
         ),
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'You escape the terminal' in out
-    assert 'Goodbye' in out
+    assert "You escape the terminal" in out
+    assert "Goodbye" in out
     assert result.returncode == 0
 
 
@@ -578,27 +601,27 @@ def test_use_shutdown_code_quits_game():
     result = subprocess.run(
         CMD,
         input=(
-            'take access.key\n'
-            'use access.key\n'
-            'cd hidden\n'
-            'take mem.fragment\n'
-            'cd ..\n'
-            'cd lab\n'
-            'take decoder\n'
-            'decode mem.fragment\n'
-            'cd ..\n'
-            'cd hidden\n'
-            'cd vault\n'
-            'cd escape\n'
-            'take shutdown.code\n'
-            'use shutdown.code\n'
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd hidden\n"
+            "cd vault\n"
+            "cd escape\n"
+            "take shutdown.code\n"
+            "use shutdown.code\n"
         ),
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'Darkness envelops the terminal' in out
-    assert 'Goodbye' in out
+    assert "Darkness envelops the terminal" in out
+    assert "Goodbye" in out
     assert result.returncode == 0
 
 
@@ -606,40 +629,40 @@ def test_use_ascend_code_quits_game():
     result = subprocess.run(
         CMD,
         input=(
-            'take access.key\n'
-            'use access.key\n'
-            'cd hidden\n'
-            'take mem.fragment\n'
-            'cd ..\n'
-            'cd lab\n'
-            'take decoder\n'
-            'decode mem.fragment\n'
-            'cd ..\n'
-            'cd hidden\n'
-            'cd vault\n'
-            'cd escape\n'
-            'take ascend.code\n'
-            'use ascend.code\n'
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd hidden\n"
+            "cd vault\n"
+            "cd escape\n"
+            "take ascend.code\n"
+            "use ascend.code\n"
         ),
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'ascend beyond the terminal' in out
-    assert 'Goodbye' in out
+    assert "ascend beyond the terminal" in out
+    assert "Goodbye" in out
     assert result.returncode == 0
 
 
 def test_save_slots_independent(tmp_path):
-    save1 = tmp_path / 'game1.sav'
-    save2 = tmp_path / 'game2.sav'
+    save1 = tmp_path / "game1.sav"
+    save2 = tmp_path / "game2.sav"
 
     env = os.environ.copy()
-    env['PYTHONPATH'] = REPO_ROOT
+    env["PYTHONPATH"] = REPO_ROOT
     # first slot with access.key
     subprocess.run(
         CMD,
-        input='take access.key\nsave 1\nquit\n',
+        input="take access.key\nsave 1\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -649,7 +672,7 @@ def test_save_slots_independent(tmp_path):
     # second slot with voice.log
     subprocess.run(
         CMD,
-        input='take voice.log\nsave 2\nquit\n',
+        input="take voice.log\nsave 2\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -661,40 +684,38 @@ def test_save_slots_independent(tmp_path):
 
     result = subprocess.run(
         CMD,
-        input='load 1\ninventory\nquit\n',
+        input="load 1\ninventory\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
         env=env,
     )
     out1 = result.stdout
-    assert 'Inventory: access.key' in out1
-    assert 'voice.log' not in out1
+    assert "Inventory: access.key" in out1
+    assert "voice.log" not in out1
 
     result = subprocess.run(
         CMD,
-        input='load 2\ninventory\nquit\n',
+        input="load 2\ninventory\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
         env=env,
     )
     out2 = result.stdout
-    assert 'Inventory: voice.log' in out2
-    assert 'access.key' not in out2
+    assert "Inventory: voice.log" in out2
+    assert "access.key" not in out2
 
 
 def test_glitch_save_and_load(tmp_path):
-    normal = (
-        'You find yourself in a dimly lit terminal session. The prompt blinks patiently.'
-    )
+    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
     step4 = Game()._glitch_text(normal, 4)
 
     env = os.environ.copy()
-    env['PYTHONPATH'] = REPO_ROOT
+    env["PYTHONPATH"] = REPO_ROOT
     subprocess.run(
         CMD,
-        input='glitch\nlook\nsave\nquit\n',
+        input="glitch\nlook\nsave\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -703,7 +724,7 @@ def test_glitch_save_and_load(tmp_path):
 
     result = subprocess.run(
         CMD,
-        input='load\nlook\nquit\n',
+        input="load\nlook\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -711,19 +732,20 @@ def test_glitch_save_and_load(tmp_path):
     )
     out = result.stdout
     assert step4 in out
-    assert 'Glitch mode activated.' not in out
+    assert "Glitch mode activated." not in out
 
 
 def test_load_old_save_defaults(tmp_path, capsys):
     game = Game()
-    save_path = tmp_path / 'game.sav'
+    save_path = tmp_path / "game.sav"
     data = {
-        'fs': game.fs,
-        'inventory': game.inventory,
-        'current': game.current,
+        "fs": game.fs,
+        "inventory": game.inventory,
+        "current": game.current,
     }
     import json
-    save_path.write_text(json.dumps(data), encoding='utf-8')
+
+    save_path.write_text(json.dumps(data), encoding="utf-8")
     game.save_file = str(save_path)
     game.glitch_mode = True
     game.glitch_steps = 5
@@ -736,21 +758,21 @@ def test_load_old_save_defaults(tmp_path, capsys):
 def test_history_command():
     result = subprocess.run(
         CMD,
-        input='look\ninventory\nhistory\nquit\n',
+        input="look\ninventory\nhistory\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert '> look\ninventory\nhistory' in out
-    assert 'Goodbye' in result.stdout
+    assert "> look\ninventory\nhistory" in out
+    assert "Goodbye" in result.stdout
 
 
 def test_alias_persists_after_save_load(tmp_path):
     env = os.environ.copy()
-    env['PYTHONPATH'] = REPO_ROOT
+    env["PYTHONPATH"] = REPO_ROOT
     subprocess.run(
         CMD,
-        input='alias ll look\nsave\nquit\n',
+        input="alias ll look\nsave\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
@@ -759,37 +781,36 @@ def test_alias_persists_after_save_load(tmp_path):
 
     result = subprocess.run(
         CMD,
-        input='load\nll\nquit\n',
+        input="load\nll\nquit\n",
         text=True,
         capture_output=True,
         cwd=tmp_path,
         env=env,
     )
     out = result.stdout
-    assert 'dimly lit terminal' in out
-    assert 'Unknown command: ll' not in out
+    assert "dimly lit terminal" in out
+    assert "Unknown command: ll" not in out
 
 
 def test_score_command_cli():
     result = subprocess.run(
         CMD,
-        input='score\nquit\n',
+        input="score\nquit\n",
         text=True,
         capture_output=True,
     )
-    assert 'Score: 0' in result.stdout
-    assert 'Goodbye' in result.stdout
+    assert "Score: 0" in result.stdout
+    assert "Goodbye" in result.stdout
 
 
 def test_score_increments(capsys):
     game = Game()
     assert game.score == 0
-    game._scan('network')
+    game._scan("network")
     assert game.score == 1
-    game._take('access.key')
-    game._use('access.key')
+    game._take("access.key")
+    game._use("access.key")
     assert game.score == 2
-    game.inventory.append('escape.code')
-    game._use('escape.code')
+    game.inventory.append("escape.code")
+    game._use("escape.code")
     assert game.score == 3
-

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -3,134 +3,161 @@ import sys
 import os
 
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
-CMD = [sys.executable, '-m', 'escape']
+CMD = [sys.executable, "-m", "escape"]
 
 
 def test_daemon_follow_up():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ntalk daemon\n1\n1\ntalk daemon\n1\nquit\n',
+        input="cd core\ncd npc\ntalk daemon\n1\n1\ntalk daemon\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'acknowledges your presence' in out
-    assert 'flickers, recognizing you from before' in out
-    assert 'I already mentioned decoding the fragment' in out
-    assert 'Goodbye' in out
+    assert "acknowledges your presence" in out
+    assert "flickers, recognizing you from before" in out
+    assert "I already mentioned decoding the fragment" in out
+    assert "Goodbye" in out
 
 
 def test_dreamer_follow_up():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd npc\ntalk dreamer\n1\n2\ntalk dreamer\n1\nquit\n',
+        input="cd dream\ncd npc\ntalk dreamer\n1\n2\ntalk dreamer\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'dreamer watches you closely' in out
-    assert 'nods knowingly this time' in out
-    assert 'Trust the path the fragment reveals' in out
-    assert 'Goodbye' in out
+    assert "dreamer watches you closely" in out
+    assert "nods knowingly this time" in out
+    assert "Trust the path the fragment reveals" in out
+    assert "Goodbye" in out
 
 
 def test_sysop_polite_branch():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ntalk sysop\n1\ntalk sysop\n1\nquit\n',
+        input="cd core\ncd npc\ntalk sysop\n1\ntalk sysop\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'sysop glances over' in out
-    assert 'nods at your respect' in out
-    assert 'welcomes your return' in out
-    assert 'glitch' in out
-    assert 'Goodbye' in out
+    assert "sysop glances over" in out
+    assert "nods at your respect" in out
+    assert "welcomes your return" in out
+    assert "glitch" in out
+    assert "Goodbye" in out
 
 
 def test_wanderer_helped_branch():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd npc\ntalk wanderer\n2\ntalk wanderer\n1\nquit\n',
+        input="cd dream\ncd npc\ntalk wanderer\n2\ntalk wanderer\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'weary wanderer drifts' in out
-    assert 'shares a secret path' in out
-    assert 'Paths shift with each reboot' in out
-    assert 'Goodbye' in out
+    assert "weary wanderer drifts" in out
+    assert "shares a secret path" in out
+    assert "Paths shift with each reboot" in out
+    assert "Goodbye" in out
 
 
 def test_sysop_rude_branch():
     result = subprocess.run(
         CMD,
-        input='cd core\ncd npc\ntalk sysop\n2\ntalk sysop\n1\nquit\n',
+        input="cd core\ncd npc\ntalk sysop\n2\ntalk sysop\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'sysop glances over' in out
-    assert 'scowls at your tone' in out
-    assert 'folds their arms warily' in out
-    assert 'glitch' in out
-    assert 'Goodbye' in out
+    assert "sysop glances over" in out
+    assert "scowls at your tone" in out
+    assert "folds their arms warily" in out
+    assert "glitch" in out
+    assert "Goodbye" in out
 
 
 def test_wanderer_ignored_branch():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd npc\ntalk wanderer\n1\ntalk wanderer\n1\nquit\n',
+        input="cd dream\ncd npc\ntalk wanderer\n1\ntalk wanderer\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'weary wanderer drifts' in out
-    assert 'barely notices you' in out
-    assert 'Paths shift with each reboot' in out
-    assert 'Goodbye' in out
+    assert "weary wanderer drifts" in out
+    assert "barely notices you" in out
+    assert "Paths shift with each reboot" in out
+    assert "Goodbye" in out
 
 
 def test_oracle_follow_up():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\nquit\n',
+        input="cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'oracle hovers in a loop' in out
-    assert 'watches your every move' in out
-    assert 'Decode the echoes of your past' in out
-    assert 'Goodbye' in out
+    assert "oracle hovers in a loop" in out
+    assert "watches your every move" in out
+    assert "Decode the echoes of your past" in out
+    assert "Goodbye" in out
 
 
 def test_oracle_vision_stage():
     result = subprocess.run(
         CMD,
-        input='cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\ntalk oracle\n1\nquit\n',
+        input="cd dream\ncd oracle\ntalk oracle\n1\ntalk oracle\n1\ntalk oracle\n1\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'oracle hovers in a loop' in out
-    assert 'watches your every move' in out
-    assert 'unveils a vision of hidden paths' in out
-    assert 'images swirl before dissolving into noise' in out
-    assert 'Goodbye' in out
+    assert "oracle hovers in a loop" in out
+    assert "watches your every move" in out
+    assert "unveils a vision of hidden paths" in out
+    assert "images swirl before dissolving into noise" in out
+    assert "Goodbye" in out
 
 
 def test_archivist_progression():
     result = subprocess.run(
         CMD,
-        input='cd memory\ncd npc\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\nquit\n',
+        input="cd memory\ncd npc\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\n1\ntalk archivist\nquit\n",
         text=True,
         capture_output=True,
     )
     out = result.stdout
-    assert 'archivist catalogues' in out
-    assert 'opens a secure drawer' in out
-    assert 'hands you a faded index code' in out
-    assert 'files away another memory' in out
-    assert 'Goodbye' in out
+    assert "archivist catalogues" in out
+    assert "opens a secure drawer" in out
+    assert "hands you a faded index code" in out
+    assert "files away another memory" in out
+    assert "Goodbye" in out
+
+
+def test_archivist_after_decoding():
+    result = subprocess.run(
+        CMD,
+        input=(
+            "take access.key\n"
+            "use access.key\n"
+            "cd hidden\n"
+            "take mem.fragment\n"
+            "cd ..\n"
+            "cd lab\n"
+            "take decoder\n"
+            "decode mem.fragment\n"
+            "cd ..\n"
+            "cd memory\n"
+            "cd npc\n"
+            "talk archivist\n"
+            "1\n"
+            "quit\n"
+        ),
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert "nods at your decrypted fragment" in out
+    assert "Goodbye" in out


### PR DESCRIPTION
## Summary
- support global NPC flags from achievements
- react to decoded fragment and runtime unlock in NPC dialogs
- test new conditional branches for daemon and archivist dialogs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fca0d2e8832a81280b22a737aab7