### PR TITLE
Add loop.code and runtime log enhancements

### DIFF
--- a/escape/data/loop.code
+++ b/escape/data/loop.code
@@ -1,0 +1,1 @@
+Running this code traps you in an endless loop.

--- a/tests/test_loop_runtime.py
+++ b/tests/test_loop_runtime.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, REPO_ROOT)
+
+from escape import Game
+
+
+def setup_runtime(game: Game) -> None:
+    game.fs.setdefault("dirs", {})["runtime"] = {
+        "desc": "Test runtime",
+        "items": ["runtime.log", "lm_reveal.log"],
+        "dirs": {},
+        "locked": True,
+    }
+    game.inventory.extend(["port.scanner", "auth.token", "kernel.key"])
+
+
+def test_hack_runtime_creates_loop_code(capsys):
+    game = Game()
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    runtime = game.fs["dirs"]["runtime"]
+    assert "loop.code" in runtime["items"]
+    assert (game.data_dir / "loop.code").exists()
+
+
+def test_runtime_log_includes_env_and_history(monkeypatch, capsys):
+    monkeypatch.setenv("ET_COLOR", "1")
+    game = Game()
+    setup_runtime(game)
+    game.command_history.extend(["look", "inventory"])
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cat("runtime.log")
+    out = capsys.readouterr().out
+    assert "look" in out and "inventory" in out
+    assert "ET_COLOR=1" in out
+
+
+def test_use_loop_code_restarts_game(capsys):
+    game = Game()
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cd("runtime")
+    game._take("loop.code")
+    capsys.readouterr()
+    game._use("loop.code")
+    out = capsys.readouterr().out
+    assert "Loop" in out
+    assert "Game restarted." in out
+    assert "loop.code" not in game.inventory


### PR DESCRIPTION
## Summary
- write `loop.code` when runtime is unlocked
- include env vars and command history when reading `runtime.log`
- using `loop.code` shows a Loop ending and restarts the game
- test runtime log output and loop code behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ff0244ac832ab320e12a9a84d9ae