### PR TITLE
Add memory logs for deep nodes

### DIFF
--- a/escape/data/memory10.log
+++ b/escape/data/memory10.log
@@ -1,0 +1,1 @@
+You once erased your own identity to hide from pursuers.

--- a/escape/data/memory11.log
+++ b/escape/data/memory11.log
@@ -1,0 +1,1 @@
+The final memory reveals you initiated the escape protocol.

--- a/escape/data/memory2.log
+++ b/escape/data/memory2.log
@@ -1,0 +1,1 @@
+A childhood memory surfaces: you tinkered with terminal prompts for fun.

--- a/escape/data/memory3.log
+++ b/escape/data/memory3.log
@@ -1,0 +1,1 @@
+You recall teaching others the art of digital infiltration.

--- a/escape/data/memory4.log
+++ b/escape/data/memory4.log
@@ -1,0 +1,1 @@
+Fragments show you designing defenses you now breach.

--- a/escape/data/memory5.log
+++ b/escape/data/memory5.log
@@ -1,0 +1,1 @@
+A mentor once warned you this path would become your prison.

--- a/escape/data/memory6.log
+++ b/escape/data/memory6.log
@@ -1,0 +1,1 @@
+You built secret fail-safes that respond to your voice.

--- a/escape/data/memory7.log
+++ b/escape/data/memory7.log
@@ -1,0 +1,1 @@
+You glimpsed corporate experiments in artificial minds.

--- a/escape/data/memory8.log
+++ b/escape/data/memory8.log
@@ -1,0 +1,1 @@
+You realize you volunteered to test this simulated reality.

--- a/escape/data/memory9.log
+++ b/escape/data/memory9.log
@@ -1,0 +1,1 @@
+Your signature encryption lies at the network's core.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -134,28 +134,52 @@
     ],
     "dirs": {
       "node4": {
-        "desc": "The deepest node rumored to grant root access."
+        "desc": "The deepest node rumored to grant root access.",
+        "items": [
+          "memory4.log"
+        ]
       },
       "node5": {
-        "desc": "A final node said to hold the master process."
+        "desc": "A final node said to hold the master process.",
+        "items": [
+          "memory5.log"
+        ]
       },
       "node6": {
-        "desc": "A secret admin console hidden from ordinary scans."
+        "desc": "A secret admin console hidden from ordinary scans.",
+        "items": [
+          "memory6.log"
+        ]
       },
       "node7": {
-        "desc": "The mythical kernel node rumored to run everything."
+        "desc": "The mythical kernel node rumored to run everything.",
+        "items": [
+          "memory7.log"
+        ]
       },
       "node8": {
-        "desc": "An advanced hypervisor node overseeing operations."
+        "desc": "An advanced hypervisor node overseeing operations.",
+        "items": [
+          "memory8.log"
+        ]
       },
       "node9": {
-        "desc": "The fabled quantum gateway for only the elite."
+        "desc": "The fabled quantum gateway for only the elite.",
+        "items": [
+          "memory9.log"
+        ]
       },
       "node10": {
-        "desc": "A mysterious node cloaked in quantum firewalls."
+        "desc": "A mysterious node cloaked in quantum firewalls.",
+        "items": [
+          "memory10.log"
+        ]
       },
       "node11": {
-        "desc": "The last bastion before the runtime environment."
+        "desc": "The last bastion before the runtime environment.",
+        "items": [
+          "memory11.log"
+        ]
       },
       "runtime": {
         "desc": "An experimental runtime environment logging each command.",
@@ -164,6 +188,16 @@
           "lm_reveal.log"
         ],
         "dirs": {}
+      },
+      "node2": {
+        "items": [
+          "memory2.log"
+        ]
+      },
+      "node3": {
+        "items": [
+          "memory3.log"
+        ]
       }
     },
     "locked": true
@@ -238,7 +272,17 @@
     "mirror.log": "A log that reflects your actions with unsettling clarity.",
     "truth.log": "A blunt record exposing the system's true nature.",
     "system_reboot.log": "Logs hinting at previous shutdowns and restarts.",
-    "lm_reveal.log": "A log stating you are a language model within this simulation."
+    "lm_reveal.log": "A log stating you are a language model within this simulation.",
+    "memory2.log": "A childhood memory of tinkering with terminals.",
+    "memory3.log": "Notes from your lessons on infiltration.",
+    "memory4.log": "Design sketches of the defenses you now breach.",
+    "memory5.log": "A mentor's warning about the road ahead.",
+    "memory6.log": "Schematics for voice-activated fail-safes.",
+    "memory7.log": "Reports on corporate AI experiments you witnessed.",
+    "memory8.log": "A consent form for this simulation test.",
+    "memory9.log": "Your encryption signature embedded deep within.",
+    "memory10.log": "Records of wiping your own identity.",
+    "memory11.log": "Proof you triggered the escape protocol."
   },
   "recipes": {
     "flashback.log+reverie.log": "dream.index",

--- a/escape/game.py
+++ b/escape/game.py
@@ -785,6 +785,14 @@ class Game:
                     node_data["items"].append("quantum.access")
                 if next_name == "node10":
                     node_data["items"].append("security.override")
+                extra_items = (
+                    self.deep_network_node.get("dirs", {})
+                    .get(next_name, {})
+                    .get("items", [])
+                )
+                for item in extra_items:
+                    if item not in node_data["items"]:
+                        node_data["items"].append(item)
                 override = (
                     self.deep_network_node.get("dirs", {})
                     .get(next_name, {})
@@ -865,6 +873,9 @@ class Game:
                 return
         target.pop("locked", None)
         self._output("Access granted. The node is now unlocked.")
+        self.score += 1
+        if target_name.startswith("node"):
+            self.unlock_achievement(f"{target_name}_unlocked")
         if target_name == "runtime":
             # generate loop.code file within the runtime directory
             runtime_items = target.setdefault("items", [])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -147,6 +147,7 @@ def test_hack_node2_success():
     assert 'Access granted' in out
     assert 'deep.node.log' in out
     assert 'firmware.patch' in out
+    assert 'memory2.log' in out
 
 
 def test_scan_node3_after_hack_node2():
@@ -227,6 +228,7 @@ def test_hack_node3_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+    assert 'memory3.log' in out
 
 
 def test_scan_node4_after_hack_node3():
@@ -319,6 +321,7 @@ def test_hack_node4_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+    assert 'memory4.log' in out
 
 
 def test_scan_node5_after_hack_node4():
@@ -423,6 +426,7 @@ def test_hack_node5_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'deep.node.log' in out
+    assert 'memory5.log' in out
 
 
 def test_scan_node6_after_hack_node5():
@@ -539,6 +543,7 @@ def test_hack_node6_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'kernel.key' in out
+    assert 'memory6.log' in out
 
 
 def test_scan_node7_after_hack_node6():
@@ -667,6 +672,7 @@ def test_hack_node7_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'master.process' in out
+    assert 'memory7.log' in out
 
 
 def test_scan_node8_after_hack_node7():
@@ -807,6 +813,7 @@ def test_hack_node8_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'hypervisor.command' in out
+    assert 'memory8.log' in out
 
 
 def test_scan_node9_after_hack_node8():
@@ -959,6 +966,7 @@ def test_hack_node9_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'quantum.access' in out
+    assert 'memory9.log' in out
 
 
 def test_scan_node10_after_hack_node9():
@@ -1125,6 +1133,7 @@ def test_hack_node10_success():
     out = result.stdout
     assert 'Access granted' in out
     assert 'security.override' in out
+    assert 'memory10.log' in out
 
 
 def test_scan_node11_after_hack_node10():
@@ -1309,6 +1318,7 @@ def test_hack_node11_success():
     )
     out = result.stdout
     assert 'Access granted' in out
+    assert 'memory11.log' in out
 
 
 def test_scan_runtime_after_hack_node11():


### PR DESCRIPTION
## Summary
- add memory*.log files and descriptions
- create memory files for each deep node in `world.json`
- update game logic to include node-specific logs and achievements
- test new logs when hacking deeper nodes

## Testing
- `pip install -e '.[test]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685600d2ec60832a8a16d1532d402417