### PR TITLE
Add quest progression for runtime

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -640,7 +640,8 @@ class Game:
             return
         self.inventory.remove(target)
         vault = self.hidden_dir["dirs"]["vault"]
-        if "escape" not in vault["dirs"]:
+        first_time = "escape" not in vault["dirs"]
+        if first_time:
             vault["dirs"]["escape"] = {
                 "desc": "A compartment revealed by decoding the fragment.",
                 "items": ["escape.code", "shutdown.code", "ascend.code"],
@@ -648,6 +649,8 @@ class Game:
             }
             self.unlock_achievement("fragment_decoded")
             self.npc_global_flags["decoded"] = True
+            if "Trace your runtime origin." not in self.quests:
+                self.quests.append("Trace your runtime origin.")
         self._output(
             "The decoder hums and a new directory appears within hidden/vault."
         )
@@ -894,6 +897,10 @@ class Game:
                 pass
             self.unlock_achievement("runtime_unlocked")
             self.npc_global_flags["runtime"] = True
+            if "Trace your runtime origin." in self.quests:
+                self.quests.remove("Trace your runtime origin.")
+            if "Decide your fate" not in self.quests:
+                self.quests.append("Decide your fate")
             try:
                 msg = (
                     (self.data_dir / "lm_reveal.log")

--- a/tests/test_quest_runtime.py
+++ b/tests/test_quest_runtime.py
@@ -1,0 +1,30 @@
+from escape import Game
+
+
+def setup_runtime(game: Game) -> None:
+    game.fs.setdefault("dirs", {})["runtime"] = {
+        "desc": "Test runtime",
+        "items": ["runtime.log", "lm_reveal.log"],
+        "dirs": {},
+        "locked": True,
+    }
+    game.inventory.extend(["port.scanner", "auth.token", "kernel.key"])
+
+
+def test_decode_adds_runtime_quest():
+    game = Game()
+    game.inventory.extend(["decoder", "mem.fragment"])
+    game._decode("mem.fragment")
+    assert game.quests == ["Recover your lost memory", "Trace your runtime origin."]
+
+
+def test_hack_runtime_updates_quests(capsys):
+    game = Game()
+    game.inventory.extend(["decoder", "mem.fragment"])
+    game._decode("mem.fragment")
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    assert "Trace your runtime origin." not in game.quests
+    assert "Decide your fate" in game.quests
+


### PR DESCRIPTION
## Summary
- add quest update when decoding mem.fragment
- complete quest & add next quest when hacking runtime
- test quest list after decoding mem.fragment
- test quest updates after hacking runtime

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685604b277a8832a8d1d9ebae6c9e8af