### PR TITLE
Add door to root directory and tests

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -1,9 +1,10 @@
 {
   "fs": {
-    "desc": "You find yourself in a dimly lit terminal session. The prompt blinks patiently.",
+    "desc": "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently.",
     "items": [
       "access.key",
-      "voice.log"
+      "voice.log",
+      "door"
     ],
     "dirs": {
       "lab": {
@@ -238,6 +239,7 @@
   },
   "item_descriptions": {
     "access.key": "A slim digital token rumored to unlock hidden directories.",
+    "door": "A closed panel concealing something behind it.",
     "treasure.txt": "A file filled with untold riches.",
     "mem.fragment": "A corrupted memory fragment pulsing faintly with data.",
     "mem.part1": "One fragment of a larger memory sequence.",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,6 +28,7 @@ def test_look_command():
     assert "dimly lit terminal" in result.stdout
     assert "access.key" in result.stdout
     assert "voice.log" in result.stdout
+    assert "door" in result.stdout
     assert "Goodbye" in result.stdout
 
 
@@ -396,7 +397,7 @@ def test_cat_treasure_after_unlock():
 
 
 def test_glitch_mode_toggle():
-    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
     first_glitch = Game()._glitch_text(normal, 1)
     result = subprocess.run(
         CMD,
@@ -412,7 +413,7 @@ def test_glitch_mode_toggle():
 
 
 def test_glitch_persistence():
-    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
     first_glitch = Game()._glitch_text(normal, 1)
     later_glitch = Game()._glitch_text(normal, 3)
     result = subprocess.run(
@@ -429,7 +430,7 @@ def test_glitch_persistence():
 
 
 def test_glitch_intensity_increases():
-    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
     step1 = Game()._glitch_text(normal, 1)
     step3 = Game()._glitch_text(normal, 3)
     step5 = Game()._glitch_text(normal, 5)
@@ -708,7 +709,7 @@ def test_save_slots_independent(tmp_path):
 
 
 def test_glitch_save_and_load(tmp_path):
-    normal = "You find yourself in a dimly lit terminal session. The prompt blinks patiently."
+    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
     step4 = Game()._glitch_text(normal, 4)
 
     env = os.environ.copy()

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -89,7 +89,7 @@ def test_glitch_thresholds_modify_fs(capsys):
     for _ in range(5):
         game._output('tick')
     import random
-    expected = ['access.key', 'voice.log']
+    expected = ['access.key', 'voice.log', 'door']
     rnd = random.Random(20)
     rnd.shuffle(expected)
     assert game.fs['items'] == expected


### PR DESCRIPTION
## Summary
- reveal a door item at the root of the filesystem
- describe the door and mention it in the starting room
- expect the door when looking around
- keep new features tests consistent with the door entry

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685607c8c91c832aacca1ec89131851f