### PR TITLE
Improve help output listing

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -481,11 +481,11 @@ class Game:
             else:
                 self._output(f"No help available for '{command}'.")
             return
-        self._output(
-            "Available commands: help, look, ls, cd <dir>, pwd, take <item>, drop <item>, "
-            "inventory, examine <item>, use <item> [on <target>], cat <file>, talk <npc>, "
-            "save [slot], load [slot], color [on|off|toggle], glitch, alias <name> <cmd>, unalias <name>, quit"
-        )
+
+        self._output("Available commands:")
+        for cmd in sorted(self.command_descriptions):
+            desc = self.command_descriptions[cmd]
+            self._output(f"{cmd}: {desc}")
 
     def _current_node(self):
         node = self.fs

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -129,8 +129,11 @@ def test_help_alias():
         text=True,
         capture_output=True,
     )
-    assert "Available commands" in result.stdout
-    assert "Goodbye" in result.stdout
+    out = result.stdout
+    assert "Available commands:" in out
+    assert "help: Show help for commands" in out
+    assert "quit: Exit the game" in out
+    assert "Goodbye" in out
 
 
 def test_help_specific_command():

--- a/tests/test_help_all_commands.py
+++ b/tests/test_help_all_commands.py
@@ -4,11 +4,15 @@ from pathlib import Path
 from escape import Game
 
 
-def test_help_for_each_command(capsys):
+def test_help_lists_all_commands(capsys):
     game = Game()
     man_dir = Path(game.data_dir) / "man"
+    game._print_help()
+    out = capsys.readouterr().out
+    lines = [line.strip() for line in out.splitlines() if line.strip()]
+    assert lines[0] == "Available commands:"
+    listed_cmds = [line.split(":", 1)[0] for line in lines[1:]]
+    assert listed_cmds == sorted(listed_cmds)
     for cmd, desc in game.command_descriptions.items():
-        game._print_help(cmd)
-        out = capsys.readouterr().out
         assert f"{cmd}: {desc}" in out
         assert (man_dir / f"{cmd}.man").exists()


### PR DESCRIPTION
## Summary
- show all commands and descriptions in `Game._print_help`
- update help-related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685608e5cd3c832abe1b1c472feae6cc