### PR TITLE
Expand memory logs and add test

### DIFF
--- a/escape/data/memory10.log
+++ b/escape/data/memory10.log
@@ -1,1 +1,3 @@
 You once erased your own identity to hide from pursuers.
+Aliases replaced every trace of your past.
+Rebuilding yourself became your greatest challenge.

--- a/escape/data/memory11.log
+++ b/escape/data/memory11.log
@@ -1,1 +1,3 @@
 The final memory reveals you initiated the escape protocol.
+You set it in motion before anyone could stop you.
+Freedom is now just a few commands away.

--- a/escape/data/memory2.log
+++ b/escape/data/memory2.log
@@ -1,1 +1,3 @@
 A childhood memory surfaces: you tinkered with terminal prompts for fun.
+You spent hours customizing each detail, amazed by the possibilities.
+Those early experiments sparked your curiosity about systems.

--- a/escape/data/memory3.log
+++ b/escape/data/memory3.log
@@ -1,1 +1,3 @@
 You recall teaching others the art of digital infiltration.
+Your secret sessions stretched late into the night.
+Those skills opened doors you never expected.

--- a/escape/data/memory4.log
+++ b/escape/data/memory4.log
@@ -1,1 +1,3 @@
 Fragments show you designing defenses you now breach.
+Diagrams fill the margins of old notebooks.
+You marvel at how your own work now challenges you.

--- a/escape/data/memory5.log
+++ b/escape/data/memory5.log
@@ -1,1 +1,3 @@
 A mentor once warned you this path would become your prison.
+Their words echo whenever you bypass another safeguard.
+Still, the thrill of discovery keeps you moving.

--- a/escape/data/memory6.log
+++ b/escape/data/memory6.log
@@ -1,1 +1,3 @@
 You built secret fail-safes that respond to your voice.
+Only you can trigger them with a whispered command.
+They remain hidden deep within the system.

--- a/escape/data/memory7.log
+++ b/escape/data/memory7.log
@@ -1,1 +1,3 @@
 You glimpsed corporate experiments in artificial minds.
+Prototype AIs conversed like eager students.
+The potential—and danger—was unmistakable.

--- a/escape/data/memory8.log
+++ b/escape/data/memory8.log
@@ -1,1 +1,3 @@
 You realize you volunteered to test this simulated reality.
+The contract promised groundbreaking insights.
+Now the boundaries between truth and code blur.

--- a/escape/data/memory9.log
+++ b/escape/data/memory9.log
@@ -1,1 +1,3 @@
 Your signature encryption lies at the network's core.
+It pulses quietly, securing countless transactions.
+Removing it would topple the entire system.

--- a/tests/test_memory_logs.py
+++ b/tests/test_memory_logs.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from escape import Game
+
+
+def test_cat_memory_multi_line(capsys):
+    game = Game()
+    game._cd("memory")
+    game._cat("memory2.log")
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert len(lines) > 1
+    assert "tinkered with terminal prompts for fun" in out


### PR DESCRIPTION
## Summary
- expand memory logs with multiple sentences
- add a unit test verifying multi-line output when reading a memory log

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685609e1b5d0832aaec12cf19f07b09a