### PR TITLE
Add extra daemon & dreamer dialog sections

### DIFF
--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -26,3 +26,7 @@ The daemon analyzes the decoded fragment you present.
 "Use this trust wisely."
 ---
 The daemon has nothing more to say.
+---
+?decoded:The daemon processes your decrypted data with newfound respect.
+?runtime:The daemon warns that loops in the runtime may ensnare you.
+"The daemon's voice fades as it awaits further directives."

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -24,3 +24,7 @@ The dreamer watches you closely.
 ---
 ?glitched:The dreamer dissolves into static.
 ?!glitched:The dreamer has retreated into silence.
+---
+?decoded:The dreamer whispers of realities unlocked by your decoding.
+?runtime:The dreamer wonders if your runtime can shape dreams.
+The dream dims, leaving you in quiet contemplation.

--- a/tests/test_dialog_extension.py
+++ b/tests/test_dialog_extension.py
@@ -1,0 +1,30 @@
+import builtins
+from escape import Game
+
+
+def test_daemon_additional_section(monkeypatch, capsys):
+    game = Game()
+    game.npc_global_flags['decoded'] = True
+    game.npc_global_flags['runtime'] = True
+    game._cd('core')
+    game._cd('npc')
+    inputs = iter(['1', '1', '1', '1', '1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    for _ in range(6):
+        game._talk('daemon')
+    out = capsys.readouterr().out
+    assert "voice fades as it awaits further directives" in out
+
+
+def test_dreamer_additional_section(monkeypatch, capsys):
+    game = Game()
+    game.npc_global_flags['decoded'] = True
+    game.npc_global_flags['runtime'] = True
+    game._cd('dream')
+    game._cd('npc')
+    inputs = iter(['1', '1', '1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    for _ in range(4):
+        game._talk('dreamer')
+    out = capsys.readouterr().out
+    assert "dream dims, leaving you in quiet contemplation." in out


### PR DESCRIPTION
## Summary
- expand daemon and dreamer dialog files with new conditional sections
- add tests ensuring new sections appear after previous dialog is exhausted

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560afa1e70832a9f728e0e69bb81f6