### PR TITLE
Add integration test for unlocking hidden directory

### DIFF
--- a/tests/test_hidden_directory_visibility.py
+++ b/tests/test_hidden_directory_visibility.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_hidden_directory_visible_after_unlock():
+    result = subprocess.run(
+        CMD,
+        input='ls\ntake access.key\nuse access.key on door\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    # hidden directory should not appear before using the key, but should after
+    assert out.count('hidden/') == 1
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- add a new regression test covering `take access.key` followed by `use access.key on door`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560cb294ec832ab3f7b4f3ad7caacf