### PR TITLE
Enrich NPC dialog with atmospheric details

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -1,21 +1,21 @@
-The archivist catalogues swirling fragments with meticulous precision.
-?decoded:The archivist nods at your decrypted fragment.
-?runtime:The archivist whispers of a hidden runtime.
+The archivist catalogues swirling fragments with meticulous precision, rarely looking up from their task.
+?decoded:The archivist nods at your decrypted fragment, tracing its edges with a gloved finger.
+?runtime:The archivist whispers of a hidden runtime lurking beneath corrupted memories.
 > Ask about restoring memories [+curious]
 > Browse the catalog [-curious]
 > Leave
-"These records are fragile. Treat them kindly."
+"These records are fragile, etched in fading code. Treat them kindly."
 ---
-?curious:The archivist opens a secure drawer filled with numbered logs.
-?!curious:The archivist keeps the archives at a distance.
+?curious:The archivist opens a secure drawer filled with numbered logs that glow faintly.
+?!curious:The archivist keeps the archives at a distance, protective as a gatekeeper.
 > Inquire about hidden logs [+trust]
 > Step back
-"The key to recall lies within the fragment you carry."
+"The key to recall lies within the fragment you carry; guard it well."
 ---
-?trust:The archivist hands you a faded index code.
-?!trust:The archivist resumes sorting without comment.
+?trust:The archivist hands you a faded index code, the digits smudged by time.
+?!trust:The archivist resumes sorting without comment, focus unbroken.
 > Thank the archivist
 > Depart
-"Remember: knowledge fades unless preserved."
+"Remember: knowledge fades unless it is carefully preserved."
 ---
-The archivist files away another memory and says no more.
+The archivist quietly files away another memory and says no more, disappearing into the stacks.

--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -1,32 +1,32 @@
-The daemon acknowledges your presence.
-?decoded:The daemon hums as the fragment's code becomes clear.
-?runtime:The daemon senses your runtime access.
+The daemon acknowledges your presence with a mechanical nod.
+?decoded:The daemon hums as the fragment's code becomes clear, digits dancing across its interface.
+?runtime:The daemon senses your runtime access and reroutes energy flows.
 > Ask about system status
 > Ask about hidden directories
-"Keep your code clean," it drones.
-"Perhaps there is more to learn from the fragments."
+"Keep your code clean," it drones, "corruption spreads quickly."
+"Perhaps there is more to learn from the fragments, though knowledge has a cost."
 > Request a hint
 > Leave the daemon
-"Decoding the fragment might reveal an escape path," it whispers.
+"Decoding the fragment might reveal an escape path," it whispers, as if daring you to try.
 ---
-The daemon flickers, recognizing you from before.
+The daemon flickers, recognizing you from before, patterns of light swirling.
 > Request another hint
 > Leave the daemon
-"I already mentioned decoding the fragment. Perhaps try it now."
+"I already mentioned decoding the fragment. Perhaps try it now before the trail fades."
 ---
 The daemon analyzes the decoded fragment you present.
 > Show the decoded fragment [+trust]
 > Keep the results private
-"The circuits hum with new information."
+"The circuits hum with new information, saturating the air with static."
 ---
-?trust:The daemon grants you access to hidden protocols.
-?!trust:The daemon withholds deeper knowledge.
+?trust:The daemon grants you access to hidden protocols, lines of code pulsing with power.
+?!trust:The daemon withholds deeper knowledge, its displays darkening in disapproval.
 > Explore the new access
 > Walk away
-"Use this trust wisely."
+"Use this trust wisely; the system seldom forgives betrayal."
 ---
-The daemon has nothing more to say.
+The daemon has nothing more to say, its lights dimming.
 ---
-?decoded:The daemon processes your decrypted data with newfound respect.
-?runtime:The daemon warns that loops in the runtime may ensnare you.
-"The daemon's voice fades as it awaits further directives."
+?decoded:The daemon processes your decrypted data with newfound respect, algorithms shifting in your favor.
+?runtime:The daemon warns that loops in the runtime may ensnare you, trapping the unwary.
+"The daemon's voice fades as it awaits further directives, leaving a cold hum in the air."

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -1,30 +1,30 @@
-The dreamer watches you closely.
-?decoded:The dreamer remarks on your newfound clarity.
-?runtime:The dreamer hints at a runtime beyond dreams.
-?glitched:The dreamer flickers with digital noise.
-?!glitched:The dreamer seems stable.
+The dreamer watches you closely, as though measuring your potential.
+?decoded:The dreamer remarks on your newfound clarity, a glimmer of hope in their gaze.
+?runtime:The dreamer hints at a runtime beyond dreams, where code blurs with vision.
+?glitched:The dreamer flickers with digital noise, unstable yet alluring.
+?!glitched:The dreamer seems stable, anchored in the dream's hazy logic.
 > Ask about escape
 > Ask about dreams
 > Ask about the fragment
-?glitched:The dreamer grins through static.
-?!glitched:The dreamer smiles faintly.
-?glitched:"The decoder in the lab reveals more than you expect."
-?!glitched:"The decoder in the lab will reveal what the fragment hides."
+?glitched:The dreamer grins through static, a mischievous glint in their eyes.
+?!glitched:The dreamer smiles faintly, inviting you to continue.
+?glitched:"The decoder in the lab reveals more than you expect, bending reality."
+?!glitched:"The decoder in the lab will reveal what the fragment hides, if you dare to use it."
 > Thank the dreamer
 > Return to reality
-?glitched:The dream fractures around you.
-?!glitched:The dream fades around you.
+?glitched:The dream fractures around you, shards of memory scattering.
+?!glitched:The dream fades around you, its edges dissolving.
 ---
-?glitched:The dreamer nods, leaving trailing afterimages.
-?!glitched:The dreamer nods knowingly this time.
+?glitched:The dreamer nods, leaving trailing afterimages that echo behind your eyelids.
+?!glitched:The dreamer nods knowingly this time, as if you've passed a silent test.
 > Ask again about escape
 > Wake up
-?glitched:"Trust the glitch; it leads beyond the fragment."
-?!glitched:"Trust the path the fragment reveals."
+?glitched:"Trust the glitch; it leads beyond the fragment, to places forgotten."
+?!glitched:"Trust the path the fragment reveals; it remembers you."
 ---
-?glitched:The dreamer dissolves into static.
-?!glitched:The dreamer has retreated into silence.
+?glitched:The dreamer dissolves into static, the world stuttering.
+?!glitched:The dreamer has retreated into silence, unreachable now.
 ---
-?decoded:The dreamer whispers of realities unlocked by your decoding.
-?runtime:The dreamer wonders if your runtime can shape dreams.
+?decoded:The dreamer whispers of realities unlocked by your decoding, possibilities infinite.
+?runtime:The dreamer wonders if your runtime can shape dreams, or if dreams shape runtime.
 The dream dims, leaving you in quiet contemplation.

--- a/escape/data/npc/glitcher.dialog
+++ b/escape/data/npc/glitcher.dialog
@@ -1,8 +1,8 @@
-The glitcher crackles with unstable energy.
-?decoded:The static dims at your accomplishment.
-?runtime:The glitcher vibrates, sensing the runtime breach.
+The glitcher crackles with unstable energy, lines of code twisting in the air.
+?decoded:The static dims at your accomplishment, momentarily coherent.
+?runtime:The glitcher vibrates, sensing the runtime breach with delight.
 > Observe
 > Retreat
-"Fragments... fragments everywhere."
+"Fragments... fragments everywhere, each one a broken promise."
 ---
-?*:The entity flickers out of phase.
+?*:The entity flickers out of phase, leaving ghostly afterimages.

--- a/escape/data/npc/mentor.dialog
+++ b/escape/data/npc/mentor.dialog
@@ -1,18 +1,18 @@
-The mentor studies you from behind a screen of scrolling code.
-?decoded:The mentor glances at the decoded data with interest.
-?runtime:The mentor warns you about meddling with the runtime.
+The mentor studies you from behind a screen of scrolling code, evaluating each line.
+?decoded:The mentor glances at the decoded data with interest, noting your progress.
+?runtime:The mentor warns you about meddling with the runtime, tone stern.
 > Request training [+respect]
 > Question the mentor's methods [-respect]
 > Leave
 "Focus is the foundation of mastery."
 ---
-?respect:The mentor nods approvingly at your dedication.
-?!respect:The mentor's eyes narrow at your defiance.
+?respect:The mentor nods approvingly at your dedication, satisfied.
+?!respect:The mentor's eyes narrow at your defiance, unimpressed.
 > Ask about advanced techniques [+curious]
 > Step away
 "Practice turns knowledge into skill."
 ---
-?curious:The mentor shares a final tip before returning to work.
+?curious:The mentor shares a final tip before returning to work, voice low.
 > Thank the mentor [+gratitude]
 > Depart
 "Use these lessons wisely."

--- a/escape/data/npc/oracle.dialog
+++ b/escape/data/npc/oracle.dialog
@@ -1,19 +1,19 @@
-The oracle hovers in a loop of swirling code.
-?decoded:The oracle senses the fragment has been deciphered.
-?runtime:The oracle murmurs about the unlocked runtime.
+The oracle hovers in a loop of swirling code, a ghost in the machine.
+?decoded:The oracle senses the fragment has been deciphered, eyes glimmering.
+?runtime:The oracle murmurs about the unlocked runtime, voice distant.
 > Seek prophecy [+vision]
 > Walk away [-vision]
-"The fragment only reveals its meaning in dreams."
+"The fragment only reveals its meaning in dreams; chase them well."
 ---
-The oracle watches your every move.
+The oracle watches your every move, circuits reflecting your image.
 > Ask again
 > Leave
-"Decode the echoes of your past to open the gate."
+"Decode the echoes of your past to open the gate you seek."
 ---
-?vision:The oracle unveils a vision of hidden paths.
-?!vision:The oracle's messages remain cryptic.
+?vision:The oracle unveils a vision of hidden paths, swirling with color.
+?!vision:The oracle's messages remain cryptic, lost in recursive loops.
 > Contemplate the vision
 > Step away
-"The images swirl before dissolving into noise."
+"The images swirl before dissolving into noise, leaving you dizzy."
 ---
-The oracle fades into static.
+The oracle fades into static, its presence only a memory.

--- a/escape/data/npc/sage.dialog
+++ b/escape/data/npc/sage.dialog
@@ -1,23 +1,23 @@
-The sage sits quietly among ancient files.
+The sage sits quietly among ancient files, eyes closed as if meditating.
 ?decoded:The sage acknowledges your progress with a nod.
-?runtime:The sage contemplates the runtime you uncovered.
+?runtime:The sage contemplates the runtime you uncovered, gaze distant.
 > Seek wisdom [+humble]
 > Demand secrets [-humble]
 > Leave silently
 "Patience reveals hidden truths."
 ---
-?humble:The sage smiles gently at your approach.
-?!humble:The sage eyes you warily.
+?humble:The sage smiles gently at your approach, welcoming.
+?!humble:The sage eyes you warily, suspicion plain.
 > Ask about escape [+curious]
 > Ask about the fragment [+fragment;journal=The sage hinted at a decoder in the lab.]
 > Take your leave
 "Knowledge flows to those who listen."
 ---
-?curious:The sage whispers that decoding the fragment will open new paths.
-?fragment:The sage notes the decoder in the lab may help.
+?curious:The sage whispers that decoding the fragment will open long-forgotten paths.
+?fragment:The sage notes the decoder in the lab may help, should you discover its location.
 > Offer thanks [+grateful]
 > Depart
 "The path is yours to walk."
 ---
 ?grateful:The sage blesses your journey before returning to silence.
-?!grateful:The sage resumes quiet contemplation.
+?!grateful:The sage resumes quiet contemplation, lost in thought.

--- a/escape/data/npc/sysop.dialog
+++ b/escape/data/npc/sysop.dialog
@@ -1,15 +1,15 @@
-The sysop glances over from a console.
-?decoded:The sysop comments on the decoded fragment.
-?runtime:The sysop raises an eyebrow at your runtime access.
+The sysop glances over from a console littered with blinking lights.
+?decoded:The sysop comments on the decoded fragment, impressed.
+?runtime:The sysop raises an eyebrow at your runtime access, suspicious.
 > Greet politely [+polite]
 > Demand access [-polite]
-?polite:The sysop nods at your respect.
-?!polite:The sysop scowls at your tone.
+?polite:The sysop nods at your respect, a rare gesture.
+?!polite:The sysop scowls at your tone, fingers hovering over a kill command.
 ---
-?polite:The sysop welcomes your return.
-?!polite:The sysop folds their arms warily.
+?polite:The sysop welcomes your return with a clipped nod.
+?!polite:The sysop folds their arms warily, evaluating your request.
 > Ask about commands
 > Leave
-"Try 'glitch' when things feel unstable."
+"Try 'glitch' when things feel unstable; sometimes disruption is the answer."
 ---
-The sysop is lost in system readouts.
+The sysop is lost in system readouts, attention drifting away.

--- a/escape/data/npc/wanderer.dialog
+++ b/escape/data/npc/wanderer.dialog
@@ -1,15 +1,15 @@
-A weary wanderer drifts through the data fog.
-?decoded:The wanderer recognizes the clarity in your eyes.
-?runtime:The wanderer speaks of a hidden runtime path.
+A weary wanderer drifts through the data fog, half-lost in memory.
+?decoded:The wanderer recognizes the clarity in your eyes and nods.
+?runtime:The wanderer speaks of a hidden runtime path that few ever find.
 > Ask about memories
 > Offer help [+helped]
 > Leave
-"Wander while you can, friend."
+"Wander while you can, friend; the fog consumes all."
 ---
-?helped:The wanderer smiles and shares a secret path.
-?!helped:The wanderer barely notices you.
+?helped:The wanderer smiles and shares a secret path, marking it into the dust.
+?!helped:The wanderer barely notices you, gaze drifting.
 > Seek advice
 > Leave
-"Paths shift with each reboot."
+"Paths shift with each reboot; nothing stays the same."
 ---
-The wanderer fades into the mist.
+The wanderer fades into the mist, leaving only echoes behind.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -478,7 +478,7 @@ def test_talk_dreamer():
     assert "1. Ask about escape" in out
     assert "3. Ask about the fragment" in out
     assert "Ask about escape" in out
-    assert "The decoder in the lab will reveal what the fragment hides." in out
+    assert "The decoder in the lab will reveal what the fragment hides, if you dare to use it." in out
     assert "Goodbye" in out
 
 

--- a/tests/test_glitched_dialog.py
+++ b/tests/test_glitched_dialog.py
@@ -18,7 +18,7 @@ def test_dreamer_dialog_glitched():
     from escape import Game
 
     expected = Game()._glitch_text(
-        "The dreamer flickers with digital noise.", 2
+        "The dreamer flickers with digital noise, unstable yet alluring.", 2
     )
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- rewrite NPC `.dialog` files with more flavorful descriptions
- update tests to match new dreamer dialog lines

## Testing
- `python -m escape.utils.validate_dialog escape/data/npc`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560f1f7318832ab576e5c7a5ad3548