### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ unexpected ways.
    ```
    Use `help` (or `h`) inside the game for available commands and `quit` (or `exit`) to exit.
    Common command aliases like `i`/`inv` for `inventory` and `look around` for `look` are also supported. You can also `look <dir>` to preview a subdirectory without entering it.
+   Run ``escape-terminal --version`` to print the installed version and exit.
 
    **Core commands**
    - `look [dir]` / `look around` – describe the current room or a subdirectory

--- a/escape/cli.py
+++ b/escape/cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from .game import Game
 
+import importlib.metadata
+
 
 def main(argv: list[str] | None = None):
     import argparse
@@ -26,7 +28,16 @@ def main(argv: list[str] | None = None):
         metavar="num",
         help="number of extra directories per base",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="show program version and exit",
+    )
     args = parser.parse_args(argv)
+
+    if args.version:
+        print(importlib.metadata.version("escape-the-terminal"))
+        return
 
     import os
 

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -54,3 +54,15 @@ def test_extra_count_flag():
     assert 'misty_alcove_0/' in out
     assert 'neon_alcove_0/' in out
     assert 'echoing_hall_1/' in out
+
+
+def test_version_flag():
+    import importlib.metadata
+
+    version = importlib.metadata.version('escape-the-terminal')
+    result = subprocess.run(
+        CMD + ['--version'],
+        text=True,
+        capture_output=True,
+    )
+    assert version in result.stdout


### PR DESCRIPTION
## Summary
- implement `--version` flag
- test CLI `--version` invocation
- document flag in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685611d5b83c832a95b1c9127982c003