### PR TITLE
Add sandbox area with new NPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ unexpected ways.
   - `daemon.log` – consult the system daemon when read or used, found in `core/npc/`
   - `escape.code` – the deciphered sequence unlocked within the vault
   - `port.scanner` – enables hacking of network nodes, found in the `lab/`
+  - `test.script` – an experimental file tucked away in the `sandbox/` directory
 
    **Rooms**
    - `lab/` – a cluttered research area humming with equipment
   - `archive/` – dusty shelves of old backups and forgotten notes
   - `core/npc/` – a secluded nook where a daemon awaits interaction
   - `network/` – a tangle of digital links hiding a chain of nodes down to `node7`
+  - `sandbox/` – an isolated test area for trying new commands
+  - `sandbox/npc/` – meet the sandboxer for tips on experimentation
   - `dream/oracle/` – an enigmatic hall where the oracle offers cryptic advice
 
 ## Running Tests

--- a/escape/data/npc/sandboxer.dialog
+++ b/escape/data/npc/sandboxer.dialog
@@ -1,0 +1,12 @@
+The sandboxer nods as you approach, eager to share experiments.
+> Ask about this place [+curious]
+> Leave
+"Everything here is isolated. Test freely."
+---
+?curious:The sandboxer adjusts some variables and smiles.
+> Request a sample script [+sample]
+> Say goodbye
+"Here, try running test.script to see what happens."
+---
+?sample:The sandboxer returns to tinkering, waiting for your feedback.
+

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -93,6 +93,19 @@
         "items": [],
         "dirs": {}
       },
+      "sandbox": {
+        "desc": "An isolated testing ground for experimental code.",
+        "items": [
+          "test.script"
+        ],
+        "dirs": {
+          "npc": {
+            "desc": "A tinkerer awaits feedback on new programs.",
+            "items": [],
+            "dirs": {}
+          }
+        }
+      },
       "reality": {
         "desc": "A stark directory reflecting the system's underlying truths.",
         "items": [
@@ -235,6 +248,10 @@
     "mentor": [
       "core",
       "npc"
+    ],
+    "sandboxer": [
+      "sandbox",
+      "npc"
     ]
   },
   "item_descriptions": {
@@ -268,6 +285,7 @@
     "hypervisor.command": "A privileged command set for manipulating the hypervisor.",
     "quantum.access": "An advanced key enabling entry to quantum subsystems.",
     "security.override": "A backdoor routine for bypassing advanced security.",
+    "test.script": "A disposable script used for sandbox experiments.",
     "runtime.log": "A record detailing your own execution environment.",
     "identity.log": "A personal log revealing who you truly are.",
     "dream.index": "A fused log bridging memory and dream.",

--- a/tests/test_npc_sandboxer.py
+++ b/tests/test_npc_sandboxer.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_sandboxer_first_and_second_stage():
+    result = subprocess.run(
+        CMD,
+        input='cd sandbox\ncd npc\ntalk sandboxer\n1\ntalk sandboxer\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'sandboxer nods' in out
+    assert '1. Ask about this place' in out
+    assert 'Test freely' in out
+    assert 'sandboxer adjusts' in out
+    assert 'test.script' in out
+    assert 'Goodbye' in out

--- a/tests/test_sandbox_dir.py
+++ b/tests/test_sandbox_dir.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_sandbox_directory_and_files():
+    result = subprocess.run(
+        CMD,
+        input='ls\ncd sandbox\nls\ncd npc\nls\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'sandbox/' in out
+    assert 'test.script' in out
+    assert 'npc/' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- introduce `sandbox/` with a `npc` directory in the world data
- register the new `sandboxer` NPC
- describe the sandboxer dialogue
- update README with the new area and item
- add tests for navigating to `sandbox/` and talking to the NPC

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685615099be4832abd3bf612b75bf196