### PR TITLE
Add stats command with progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ unexpected ways.
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them
   - `score` – display your current score
+  - `stats` – show counts of visited locations and items collected
   - `restart` – reset the game while keeping color settings
   - `alias <name> <command>` – create a custom shortcut
   - `unalias <name>` – remove a previously defined shortcut

--- a/docs/GAME_MECHANICS.md
+++ b/docs/GAME_MECHANICS.md
@@ -14,6 +14,17 @@ Example:
 Score: 0
 ```
 
+## Stats Overview
+Use the `stats` command to review your progress. It prints how many locations
+you have visited, how many items you've collected and your current score.
+
+```text
+> stats
+Visited locations: 1
+Items obtained: 0
+Score: 0
+```
+
 ## Restarting
 The `restart` command resets the game world and inventory while keeping any
 current color settings. It is useful for quickly starting over without leaving

--- a/escape/data/man/stats.man
+++ b/escape/data/man/stats.man
@@ -1,0 +1,3 @@
+stats - Show gameplay statistics
+Usage: stats
+Example: stats

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -818,3 +818,17 @@ def test_score_increments(capsys):
     game.inventory.append("escape.code")
     game._use("escape.code")
     assert game.score == 3
+
+
+def test_stats_counts():
+    result = subprocess.run(
+        CMD,
+        input="cd lab\ncd ..\ntake access.key\nstats\nquit\n",
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert "Visited locations: 2" in out
+    assert "Items obtained: 1" in out
+    assert "Score: 0" in out
+    assert "Goodbye" in out


### PR DESCRIPTION
## Summary
- track visited directories and collected items
- implement `stats` command to show totals
- register `stats` command and manual page
- document the new command
- test statistics reporting

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685615fb1a5c832aafb297ad5de30470