### PR TITLE
Add identity log quest and achievement

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -707,6 +707,10 @@ class Game:
             msg = self.use_messages.get("daemon.log")
             if msg:
                 self._output(msg)
+        if filename == "identity.log":
+            if "Confront your past" not in self.quests:
+                self.quests.append("Confront your past")
+            self.unlock_achievement("identity_recovered")
 
     def _man(self, command: str) -> None:
         """Display a manual page for ``command`` from data/man."""

--- a/tests/test_identity_log.py
+++ b/tests/test_identity_log.py
@@ -34,3 +34,23 @@ def test_combine_identity_log(capsys):
     game._cat('identity.log')
     log_out = capsys.readouterr().out
     assert 'architect of this terminal world' in log_out
+
+
+def test_identity_log_triggers_quest_and_achievement(capsys):
+    game = Game()
+    game._cd('memory')
+    game._take('mem.part1')
+    game._cd('..')
+    game._cd('dream')
+    game._cd('subconscious')
+    game._take('mem.part2')
+    game._cd('..')
+    game._cd('..')
+    game._combine('mem.part1 mem.part2')
+    capsys.readouterr()
+    assert 'Confront your past' not in game.quests
+    assert 'identity_recovered' not in game.achievements
+    game._cat('identity.log')
+    capsys.readouterr()
+    assert 'Confront your past' in game.quests
+    assert 'identity_recovered' in game.achievements


### PR DESCRIPTION
## Summary
- unlock `identity_recovered` achievement when reading `identity.log`
- add a `Confront your past` quest when the file is read
- test quest and achievement triggering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68561b035c9c832ab1d3bd05e766fed4