### PR TITLE
Add Guardian NPC in runtime

### DIFF
--- a/escape/data/npc/guardian.dialog
+++ b/escape/data/npc/guardian.dialog
@@ -1,0 +1,11 @@
+The guardian stands before the glowing runtime gate.
+> Request entry [+granted]
+> Step back
+"Only those cleared by the kernel may proceed."
+---
+?granted:The guardian nods solemnly as you approach.
+> Proceed
+> Leave
+"Use the runtime wisely."
+---
+The guardian resumes its silent vigil.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -201,7 +201,13 @@
           "runtime.log",
           "lm_reveal.log"
         ],
-        "dirs": {}
+        "dirs": {
+          "npc": {
+            "desc": "A vigilant guardian monitors access here.",
+            "items": [],
+            "dirs": {}
+          }
+        }
       },
       "node2": {
         "items": [
@@ -251,6 +257,11 @@
     ],
     "sandboxer": [
       "sandbox",
+      "npc"
+    ],
+    "guardian": [
+      "deep_network_node",
+      "runtime",
       "npc"
     ]
   },

--- a/escape/game.py
+++ b/escape/game.py
@@ -926,6 +926,16 @@ class Game:
                 )
             except OSError:
                 pass
+            runtime_dirs = target.setdefault("dirs", {})
+            runtime_dirs.setdefault(
+                "npc",
+                {
+                    "desc": "A vigilant guardian monitors access here.",
+                    "items": [],
+                    "dirs": {},
+                },
+            )
+            self.npc_locations["guardian"] = self.current + [directory, "npc"]
             self.unlock_achievement("runtime_unlocked")
             self.npc_global_flags["runtime"] = True
             if "Trace your runtime origin." in self.quests:

--- a/tests/test_npc_guardian.py
+++ b/tests/test_npc_guardian.py
@@ -1,0 +1,28 @@
+from escape import Game
+
+
+def setup_runtime(game: Game) -> None:
+    game.fs.setdefault("dirs", {})["runtime"] = {
+        "desc": "Test runtime",
+        "items": ["runtime.log", "lm_reveal.log"],
+        "dirs": {},
+        "locked": True,
+    }
+    game.npc_locations["guardian"] = ["runtime", "npc"]
+    game.inventory.extend(["port.scanner", "auth.token", "kernel.key"])
+
+
+def test_guardian_after_hack(monkeypatch, capsys):
+    game = Game()
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cd("runtime")
+    game._cd("npc")
+    inputs = iter(["1", "1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("guardian")
+    game._talk("guardian")
+    out = capsys.readouterr().out
+    assert "guardian stands" in out.lower()
+    assert "guardian nods solemnly" in out.lower()


### PR DESCRIPTION
## Summary
- extend runtime area with `npc` directory in `world.json`
- introduce `guardian` NPC dialog and location
- populate runtime `npc` directory when hacking runtime
- add tests covering new guardian dialogue after hacking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561bd21fb4832abfd1a650d14cff02