### PR TITLE
Add riddle plugin

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -87,3 +87,7 @@ directory and item colors explicitly.
 ## Built-in Puzzle Plugin
 
 A second bundled plugin named `puzzle.py` offers a small code-breaking riddle. Run `puzzle` without arguments to see the encoded phrase and pass your decoded answer to solve it. The module remembers if you solved the puzzle so subsequent runs simply report that it is already complete.
+
+## Built-in Riddle Plugin
+
+The `riddle.py` module presents a short question the first time you run `riddle`. Run the command again with your guess and it will tell you if you are correct.

--- a/escape/plugins/riddle.py
+++ b/escape/plugins/riddle.py
@@ -1,0 +1,24 @@
+riddle_shown = False
+_riddle = "What has to be broken before you can use it?"
+_answer = "egg"
+
+
+def riddle(arg: str = "") -> None:
+    """A simple riddle challenge."""
+    global riddle_shown
+    guess = arg.strip().lower()
+    if not riddle_shown:
+        riddle_shown = True
+        game._output(_riddle)
+        return
+    if not guess:
+        game._output("Provide your answer.")
+        return
+    if guess == _answer:
+        game._output("Correct! The riddle is solved.")
+    else:
+        game._output("Nope, try again.")
+
+
+if 'game' in globals():
+    game.command_map['riddle'] = lambda arg="": riddle(arg)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -135,6 +135,20 @@ def test_puzzle_plugin(monkeypatch, capsys):
     assert 'Correct! Puzzle solved.' in out_lines
 
 
+def test_riddle_plugin(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'riddle',
+        'riddle egg',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out_lines = capsys.readouterr().out.splitlines()
+    assert any('What has to be broken' in line for line in out_lines)
+    assert 'Correct! The riddle is solved.' in out_lines
+
+
 def test_cli_plugin_path_flag(tmp_path):
     plugin_dir = tmp_path / 'mods'
     plugin_dir.mkdir()
@@ -168,5 +182,6 @@ def test_plugins_command_lists_builtins(monkeypatch, capsys):
         'escape.plugins.dance',
         'escape.plugins.puzzle',
         'escape.plugins.theme',
+        'escape.plugins.riddle',
     }
     assert expected.issubset(set(out_lines))


### PR DESCRIPTION
## Summary
- implement a new `riddle` plugin
- document riddle plugin in plugin docs
- test that the command loads and behaves correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561f9065e4832a9e02a224b1ef0736