### PR TITLE
Add quests/achievements to stats output

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -556,9 +556,11 @@ class Game:
         self._output(f"Score: {self.score}")
 
     def _stats(self) -> None:
-        """Display counts of visited locations, collected items and score."""
+        """Display counts of visited locations, items, quests, achievements and score."""
         self._output(f"Visited locations: {len(self.visited_dirs)}")
         self._output(f"Items obtained: {len(self.collected_items)}")
+        self._output(f"Active quests: {len(self.quests)}")
+        self._output(f"Achievements unlocked: {len(self.achievements)}")
         self._output(f"Score: {self.score}")
 
     def unlock_achievement(self, name: str) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -830,5 +830,7 @@ def test_stats_counts():
     out = result.stdout
     assert "Visited locations: 2" in out
     assert "Items obtained: 1" in out
+    assert "Active quests: 1" in out
+    assert "Achievements unlocked: 0" in out
     assert "Score: 0" in out
     assert "Goodbye" in out

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,16 @@
+from escape import Game
+
+
+def test_stats_output_basic(capsys):
+    game = Game()
+    game._cd('lab')
+    game._cd('..')
+    game._take('access.key')
+    capsys.readouterr()
+    game._stats()
+    out_lines = capsys.readouterr().out.splitlines()
+    assert "Visited locations: 2" in out_lines
+    assert "Items obtained: 1" in out_lines
+    assert "Active quests: 1" in out_lines
+    assert "Achievements unlocked: 0" in out_lines
+    assert "Score: 0" in out_lines


### PR DESCRIPTION
## Summary
- extend Game._stats to show quest and achievement counts
- update stats tests in basic suite
- add a dedicated test_stats module

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856208170ec832aa3fde788bec3ed20