### PR TITLE
NPC cross references

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -3,8 +3,10 @@ The archivist catalogues swirling fragments with meticulous precision.
 ?runtime:The archivist whispers of a hidden runtime.
 > Ask about restoring memories [+curious]
 > Browse the catalog [-curious]
+> Ask about training with the mentor [+mentor_tip;journal=The archivist suggested seeking the mentor.]
 > Leave
 "These records are fragile. Treat them kindly."
+?mentor_tip:"You might consult the mentor in the core to refine your skills."
 ---
 ?curious:The archivist opens a secure drawer filled with numbered logs.
 ?!curious:The archivist keeps the archives at a distance.

--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -3,8 +3,10 @@ The daemon acknowledges your presence.
 ?runtime:The daemon senses your runtime access.
 > Ask about system status
 > Ask about hidden directories
+> Ask if the sysop can help [+sysop_hint;journal=The daemon recommended speaking with the sysop.]
 "Keep your code clean," it drones.
 "Perhaps there is more to learn from the fragments."
+?sysop_hint:"The sysop might grant you deeper command access."
 > Request a hint
 > Leave the daemon
 "Decoding the fragment might reveal an escape path," it whispers.

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -6,10 +6,12 @@ The dreamer watches you closely.
 > Ask about escape
 > Ask about dreams
 > Ask about the fragment
+> Mention the sage's wisdom [+sage_hint;journal=The dreamer advised visiting the sage.]
 ?glitched:The dreamer grins through static.
 ?!glitched:The dreamer smiles faintly.
 ?glitched:"The decoder in the lab reveals more than you expect."
 ?!glitched:"The decoder in the lab will reveal what the fragment hides."
+?sage_hint:"Seek the sage in the archives for deeper insight."
 > Thank the dreamer
 > Return to reality
 ?glitched:The dream fractures around you.

--- a/escape/data/npc/glitcher.dialog
+++ b/escape/data/npc/glitcher.dialog
@@ -3,6 +3,8 @@ The glitcher crackles with unstable energy.
 ?runtime:The glitcher vibrates, sensing the runtime breach.
 > Observe
 > Retreat
+> Ask about the guardian [+guardian_tip;journal=The glitcher whispered about the guardian.]
 "Fragments... fragments everywhere."
+?guardian_tip:"The guardian keeps the runtime stable... for now."
 ---
 ?*:The entity flickers out of phase.

--- a/escape/data/npc/guardian.dialog
+++ b/escape/data/npc/guardian.dialog
@@ -1,7 +1,9 @@
 The guardian stands before the glowing runtime gate.
 > Request entry [+granted]
 > Step back
+> Ask if the sysop can vouch for you [+sysop_hint;journal=The guardian said to gain the sysop's approval.]
 "Only those cleared by the kernel may proceed."
+?sysop_hint:"Seek the sysop's approval and return."
 ---
 ?granted:The guardian nods solemnly as you approach.
 > Proceed

--- a/escape/data/npc/mentor.dialog
+++ b/escape/data/npc/mentor.dialog
@@ -3,8 +3,10 @@ The mentor studies you from behind a screen of scrolling code.
 ?runtime:The mentor warns you about meddling with the runtime.
 > Request training [+respect]
 > Question the mentor's methods [-respect]
+> Ask about the archives [+archive_hint;journal=The mentor suggested speaking to the archivist.]
 > Leave
 "Focus is the foundation of mastery."
+?archive_hint:"The archivist in memory can help recover what you've lost."
 ---
 ?respect:The mentor nods approvingly at your dedication.
 ?!respect:The mentor's eyes narrow at your defiance.

--- a/escape/data/npc/oracle.dialog
+++ b/escape/data/npc/oracle.dialog
@@ -7,8 +7,10 @@ The oracle hovers in a loop of swirling code.
 ---
 The oracle watches your every move.
 > Ask again
+> Ask about the wanderer [+wander_hint;journal=The oracle hinted the wanderer knows the paths.]
 > Leave
 "Decode the echoes of your past to open the gate."
+?wander_hint:"Seek the wanderer among the data fog for direction."
 ---
 ?vision:The oracle unveils a vision of hidden paths.
 ?!vision:The oracle's messages remain cryptic.

--- a/escape/data/npc/sage.dialog
+++ b/escape/data/npc/sage.dialog
@@ -10,8 +10,10 @@ The sage sits quietly among ancient files.
 ?!humble:The sage eyes you warily.
 > Ask about escape [+curious]
 > Ask about the fragment [+fragment;journal=The sage hinted at a decoder in the lab.]
+> Ask about the dreamer [+dreamer_hint;journal=The sage suggested consulting the dreamer.]
 > Take your leave
 "Knowledge flows to those who listen."
+?dreamer_hint:"The dreamer may share visions beyond this archive."
 ---
 ?curious:The sage whispers that decoding the fragment will open new paths.
 ?fragment:The sage notes the decoder in the lab may help.

--- a/escape/data/npc/sandboxer.dialog
+++ b/escape/data/npc/sandboxer.dialog
@@ -1,7 +1,9 @@
 The sandboxer nods as you approach, eager to share experiments.
 > Ask about this place [+curious]
+> Ask about the glitcher [+glitcher_hint;journal=The sandboxer mentioned the glitcher.]
 > Leave
 "Everything here is isolated. Test freely."
+?glitcher_hint:"If the glitches grow, speak with the glitcher in dream." 
 ---
 ?curious:The sandboxer adjusts some variables and smiles.
 > Request a sample script [+sample]

--- a/escape/data/npc/sysop.dialog
+++ b/escape/data/npc/sysop.dialog
@@ -9,7 +9,9 @@ The sysop glances over from a console.
 ?polite:The sysop welcomes your return.
 ?!polite:The sysop folds their arms warily.
 > Ask about commands
+> Ask about the daemon [+daemon_hint;journal=The sysop suggested questioning the daemon.]
 > Leave
 "Try 'glitch' when things feel unstable."
+?daemon_hint:"The daemon in core knows many hidden routines."
 ---
 The sysop is lost in system readouts.

--- a/escape/data/npc/wanderer.dialog
+++ b/escape/data/npc/wanderer.dialog
@@ -3,8 +3,10 @@ A weary wanderer drifts through the data fog.
 ?runtime:The wanderer speaks of a hidden runtime path.
 > Ask about memories
 > Offer help [+helped]
+> Ask about the oracle [+oracle_hint;journal=The wanderer pointed toward the oracle.]
 > Leave
 "Wander while you can, friend."
+?oracle_hint:"The oracle may foresee the path you seek."
 ---
 ?helped:The wanderer smiles and shares a secret path.
 ?!helped:The wanderer barely notices you.

--- a/tests/test_npc_guardian.py
+++ b/tests/test_npc_guardian.py
@@ -25,4 +25,5 @@ def test_guardian_after_hack(monkeypatch, capsys):
     game._talk("guardian")
     out = capsys.readouterr().out
     assert "guardian stands" in out.lower()
+    assert "Ask if the sysop can vouch for you" in out
     assert "guardian nods solemnly" in out.lower()

--- a/tests/test_npc_mentor.py
+++ b/tests/test_npc_mentor.py
@@ -16,6 +16,7 @@ def test_mentor_first_and_second_stage():
     out = result.stdout
     assert 'mentor studies you' in out
     assert '1. Request training' in out
+    assert 'Ask about the archives' in out
     assert 'Focus is the foundation of mastery.' in out
     assert 'mentor nods approvingly' in out
     assert 'Practice turns knowledge into skill.' in out

--- a/tests/test_npc_sage.py
+++ b/tests/test_npc_sage.py
@@ -16,6 +16,7 @@ def test_sage_first_and_second_stage():
     out = result.stdout
     assert 'sage sits quietly' in out
     assert '1. Seek wisdom' in out
+    assert 'Ask about the dreamer' in out
     assert 'Patience reveals hidden truths.' in out
     assert 'sage smiles gently at your approach' in out
     assert 'Knowledge flows to those who listen.' in out

--- a/tests/test_npc_sandboxer.py
+++ b/tests/test_npc_sandboxer.py
@@ -16,6 +16,7 @@ def test_sandboxer_first_and_second_stage():
     out = result.stdout
     assert 'sandboxer nods' in out
     assert '1. Ask about this place' in out
+    assert 'Ask about the glitcher' in out
     assert 'Test freely' in out
     assert 'sandboxer adjusts' in out
     assert 'test.script' in out

--- a/tests/test_npc_state.py
+++ b/tests/test_npc_state.py
@@ -15,6 +15,7 @@ def test_daemon_follow_up():
     )
     out = result.stdout
     assert "acknowledges your presence" in out
+    assert "sysop can help" in out
     assert "flickers, recognizing you from before" in out
     assert "I already mentioned decoding the fragment" in out
     assert "Goodbye" in out
@@ -29,6 +30,7 @@ def test_dreamer_follow_up():
     )
     out = result.stdout
     assert "dreamer watches you closely" in out
+    assert "sage's wisdom" in out
     assert "nods knowingly this time" in out
     assert "Trust the path the fragment reveals" in out
     assert "Goodbye" in out
@@ -44,6 +46,7 @@ def test_sysop_polite_branch():
     out = result.stdout
     assert "sysop glances over" in out
     assert "nods at your respect" in out
+    assert "Ask about the daemon" in out
     assert "welcomes your return" in out
     assert "glitch" in out
     assert "Goodbye" in out
@@ -58,6 +61,7 @@ def test_wanderer_helped_branch():
     )
     out = result.stdout
     assert "weary wanderer drifts" in out
+    assert "Ask about the oracle" in out
     assert "shares a secret path" in out
     assert "Paths shift with each reboot" in out
     assert "Goodbye" in out
@@ -73,6 +77,7 @@ def test_sysop_rude_branch():
     out = result.stdout
     assert "sysop glances over" in out
     assert "scowls at your tone" in out
+    assert "Ask about the daemon" in out
     assert "folds their arms warily" in out
     assert "glitch" in out
     assert "Goodbye" in out
@@ -87,6 +92,7 @@ def test_wanderer_ignored_branch():
     )
     out = result.stdout
     assert "weary wanderer drifts" in out
+    assert "Ask about the oracle" in out
     assert "barely notices you" in out
     assert "Paths shift with each reboot" in out
     assert "Goodbye" in out
@@ -102,6 +108,7 @@ def test_oracle_follow_up():
     out = result.stdout
     assert "oracle hovers in a loop" in out
     assert "watches your every move" in out
+    assert "Ask about the wanderer" in out
     assert "Decode the echoes of your past" in out
     assert "Goodbye" in out
 
@@ -116,6 +123,7 @@ def test_oracle_vision_stage():
     out = result.stdout
     assert "oracle hovers in a loop" in out
     assert "watches your every move" in out
+    assert "Ask about the wanderer" in out
     assert "unveils a vision of hidden paths" in out
     assert "images swirl before dissolving into noise" in out
     assert "Goodbye" in out
@@ -130,6 +138,7 @@ def test_archivist_progression():
     )
     out = result.stdout
     assert "archivist catalogues" in out
+    assert "training with the mentor" in out
     assert "opens a secure drawer" in out
     assert "hands you a faded index code" in out
     assert "files away another memory" in out
@@ -160,4 +169,5 @@ def test_archivist_after_decoding():
     )
     out = result.stdout
     assert "nods at your decrypted fragment" in out
+    assert "training with the mentor" in out
     assert "Goodbye" in out


### PR DESCRIPTION
## Summary
- connect NPCs with new dialog hints
- reference other NPCs in archivist, daemon, dreamer, glitcher, guardian, mentor, oracle, sage, sandboxer, sysop and wanderer dialogs
- update NPC tests for new dialog text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685622651ae8832a9f90186b1e4289db