### PR TITLE
Add archivist quest chain

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -1,10 +1,10 @@
 The archivist catalogues swirling fragments with meticulous precision.
 ?decoded:The archivist nods at your decrypted fragment.
 ?runtime:The archivist whispers of a hidden runtime.
-> Ask about restoring memories [+curious]
-> Browse the catalog [-curious]
-> Ask about training with the mentor [+mentor_tip;journal=The archivist suggested seeking the mentor.]
-> Leave
+> Ask about restoring memories [+g+archivist_met;+curious]
+> Browse the catalog [+g+archivist_met;-curious]
+> Ask about training with the mentor [+g+archivist_met;+mentor_tip;journal=The archivist suggested seeking the mentor.]
+> Leave [+g+archivist_met]
 "These records are fragile. Treat them kindly."
 ?mentor_tip:"You might consult the mentor in the core to refine your skills."
 ---

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -3,10 +3,10 @@ The dreamer watches you closely.
 ?runtime:The dreamer hints at a runtime beyond dreams.
 ?glitched:The dreamer flickers with digital noise.
 ?!glitched:The dreamer seems stable.
-> Ask about escape
-> Ask about dreams
-> Ask about the fragment
-> Mention the sage's wisdom [+sage_hint;journal=The dreamer advised visiting the sage.]
+> Ask about escape [+g+dreamer_met]
+> Ask about dreams [+g+dreamer_met]
+> Ask about the fragment [+g+dreamer_met]
+> Mention the sage's wisdom [+g+dreamer_met;+sage_hint;journal=The dreamer advised visiting the sage.]
 ?glitched:The dreamer grins through static.
 ?!glitched:The dreamer smiles faintly.
 ?glitched:"The decoder in the lab reveals more than you expect."

--- a/escape/data/npc/guardian.dialog
+++ b/escape/data/npc/guardian.dialog
@@ -1,7 +1,7 @@
 The guardian stands before the glowing runtime gate.
-> Request entry [+granted]
-> Step back
-> Ask if the sysop can vouch for you [+sysop_hint;journal=The guardian said to gain the sysop's approval.]
+> Request entry [+g+guardian_met;+granted]
+> Step back [+g+guardian_met]
+> Ask if the sysop can vouch for you [+g+guardian_met;+sysop_hint;journal=The guardian said to gain the sysop's approval.]
 "Only those cleared by the kernel may proceed."
 ?sysop_hint:"Seek the sysop's approval and return."
 ---

--- a/escape/data/npc/mentor.dialog
+++ b/escape/data/npc/mentor.dialog
@@ -1,10 +1,10 @@
 The mentor studies you from behind a screen of scrolling code.
 ?decoded:The mentor glances at the decoded data with interest.
 ?runtime:The mentor warns you about meddling with the runtime.
-> Request training [+respect]
-> Question the mentor's methods [-respect]
-> Ask about the archives [+archive_hint;journal=The mentor suggested speaking to the archivist.]
-> Leave
+> Request training [+g+mentor_met;+respect]
+> Question the mentor's methods [+g+mentor_met;-respect]
+> Ask about the archives [+g+mentor_met;+archive_hint;journal=The mentor suggested speaking to the archivist.]
+> Leave [+g+mentor_met]
 "Focus is the foundation of mastery."
 "Bring me the lucid note from the dream if you find it."
 ?archive_hint:"The archivist in memory can help recover what you've lost."

--- a/tests/test_quest_chain.py
+++ b/tests/test_quest_chain.py
@@ -1,0 +1,63 @@
+from escape import Game
+
+
+def setup_runtime(game: Game) -> None:
+    game.fs.setdefault("dirs", {})["runtime"] = {
+        "desc": "Test runtime",
+        "items": ["runtime.log", "lm_reveal.log"],
+        "dirs": {},
+        "locked": True,
+    }
+    game.npc_locations["guardian"] = ["runtime", "npc"]
+    game.inventory.extend(["port.scanner", "auth.token", "kernel.key"])
+
+
+def test_sequential_quest_chain(monkeypatch, capsys):
+    game = Game()
+    # talk to archivist
+    game._cd("memory")
+    game._cd("npc")
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("archivist")
+    capsys.readouterr()
+    assert "Seek the dreamer" in game.quests
+
+    # talk to dreamer
+    game._cd("..")
+    game._cd("..")
+    game._cd("dream")
+    game._cd("npc")
+    inputs = iter(["1", "1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("dreamer")
+    capsys.readouterr()
+    assert "Seek the dreamer" not in game.quests
+    assert "Train with the mentor" in game.quests
+
+    # talk to mentor
+    game._cd("..")
+    game._cd("..")
+    game._cd("core")
+    game._cd("npc")
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("mentor")
+    capsys.readouterr()
+    assert "Train with the mentor" not in game.quests
+    assert "Gain the guardian's approval" in game.quests
+
+    # talk to guardian
+    game._cd("..")
+    game._cd("..")
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cd("runtime")
+    game._cd("npc")
+    inputs = iter(["1", "1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("guardian")
+    game._talk("guardian")
+    capsys.readouterr()
+    assert "Gain the guardian's approval" not in game.quests


### PR DESCRIPTION
## Summary
- extend dialog effect parsing with global flags
- add `_update_quests_after_talk` to manage NPC quest chain
- mark archivist, dreamer, mentor and guardian dialog choices with new flags
- test entire quest chain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562680721c832abe8742b8c9d87cdb