### PR TITLE
Implement NPC trust system

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -10,18 +10,19 @@ The archivist catalogues swirling fragments with meticulous precision.
 ---
 ?curious:The archivist opens a secure drawer filled with numbered logs.
 ?!curious:The archivist keeps the archives at a distance.
-> Inquire about hidden logs [+trust]
+> Inquire about hidden logs [trust+=1]
 > Step back
 "The key to recall lies within the fragment you carry."
 "If you bring me the flashback.log it will aid the archives."
 ---
-?trust:The archivist hands you a faded index code.
-?!trust:The archivist resumes sorting without comment.
+?trust>0:The archivist hands you a faded index code.
+?trust<=0:The archivist resumes sorting without comment.
 > Thank the archivist
 > Depart
 "Remember: knowledge fades unless preserved."
 ---
 The archivist files away another memory and says no more.
 ---
-?trust:The archivist awaits the promised log.
-> Discuss the flashback entry [give=flashback.log]
+?trust>0:The archivist awaits the promised log.
+> Discuss the flashback entry [give=flashback.log;trust+=1]
+?trust>1:The archivist quietly reveals a hidden backup archive.

--- a/escape/data/npc/daemon.dialog
+++ b/escape/data/npc/daemon.dialog
@@ -17,12 +17,12 @@ The daemon flickers, recognizing you from before.
 "I already mentioned decoding the fragment. Perhaps try it now."
 ---
 The daemon analyzes the decoded fragment you present.
-> Show the decoded fragment [+trust]
+> Show the decoded fragment [trust+=1]
 > Keep the results private
 "The circuits hum with new information."
 ---
-?trust:The daemon grants you access to hidden protocols.
-?!trust:The daemon withholds deeper knowledge.
+?trust>0:The daemon grants you access to hidden protocols.
+?trust<=0:The daemon withholds deeper knowledge.
 > Explore the new access
 > Walk away
 "Use this trust wisely."

--- a/tests/test_npc_trust.py
+++ b/tests/test_npc_trust.py
@@ -1,0 +1,36 @@
+import builtins
+from escape import Game
+
+
+def test_archivist_trust_increase(monkeypatch, capsys):
+    game = Game()
+    game._cd('memory')
+    game._take('flashback.log')
+    game._cd('npc')
+    inputs = iter(['1', '1', '1', '1', '1', '1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    # first conversation
+    game._talk('archivist')
+    capsys.readouterr()
+    # second conversation - choose trust option
+    game._talk('archivist')
+    capsys.readouterr()
+    assert game.npc_trust.get('archivist', 0) == 1
+    # third conversation - trust gated line should appear
+    game._talk('archivist')
+    out = capsys.readouterr().out
+    assert 'faded index code' in out
+    # give the log and gain more trust
+    game._give('flashback.log')
+    # fourth conversation reaches the waiting stage
+    game._talk('archivist')
+    capsys.readouterr()
+    # fifth conversation - choose discuss log to gain more trust
+    game._talk('archivist')
+    capsys.readouterr()
+    assert game.npc_trust.get('archivist', 0) == 2
+    # sixth conversation - new line unlocked by high trust
+    game._talk('archivist')
+    out = capsys.readouterr().out
+    assert 'hidden backup archive' in out
+


### PR DESCRIPTION
## Summary
- track trust values per NPC in Game
- support `[trust+=N]` choice markers and `?trust>N` conditions in dialogs
- adjust archivist and daemon dialogs to use trust markers
- add new dialog line unlocked at higher trust
- test trust increase and branching

## Testing
- `pip install -e '.[test]'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562a1f8efc832ab4f738f6294a7188