### PR TITLE
Add tests for give command and NPC quests

### DIFF
--- a/tests/test_give_command.py
+++ b/tests/test_give_command.py
@@ -29,3 +29,31 @@ def test_give_no_active_npc(capsys):
     out = capsys.readouterr().out
     assert 'There is no one here to give that to.' in out
     assert 'lucid.note' in game.inventory
+
+
+def test_give_item_missing(monkeypatch, capsys):
+    game = Game()
+    # talk to mentor so an NPC is active
+    game._cd('core')
+    game._cd('npc')
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('mentor')
+    capsys.readouterr()
+    game._give('lucid.note')
+    out = capsys.readouterr().out
+    assert 'You do not have lucid.note to give.' in out
+
+
+def test_give_usage(monkeypatch, capsys):
+    game = Game()
+    game.inventory.append('lucid.note')
+    game._cd('core')
+    game._cd('npc')
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('mentor')
+    capsys.readouterr()
+    game._give('')
+    out = capsys.readouterr().out
+    assert 'Usage: give <item>' in out

--- a/tests/test_npc_trust.py
+++ b/tests/test_npc_trust.py
@@ -34,3 +34,33 @@ def test_archivist_trust_increase(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert 'hidden backup archive' in out
 
+
+def test_daemon_trust_branch(monkeypatch, capsys):
+    game = Game()
+    game._cd('core')
+    game._cd('npc')
+    # first conversation requires two selections
+    inputs = iter(['1', '1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('daemon')
+    capsys.readouterr()
+
+    # second conversation
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('daemon')
+    capsys.readouterr()
+
+    # third conversation - choose trust option
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('daemon')
+    capsys.readouterr()
+
+    # trust gated line appears on fourth talk
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('daemon')
+    out = capsys.readouterr().out
+    assert 'daemon grants you access to hidden protocols' in out.lower()
+

--- a/tests/test_quest_chain.py
+++ b/tests/test_quest_chain.py
@@ -61,3 +61,55 @@ def test_sequential_quest_chain(monkeypatch, capsys):
     game._talk("guardian")
     capsys.readouterr()
     assert "Gain the guardian's approval" not in game.quests
+
+
+def test_quest_chain_final_state(monkeypatch, capsys):
+    game = Game()
+    # archivist step
+    game._cd("memory")
+    game._cd("npc")
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("archivist")
+    capsys.readouterr()
+
+    # dreamer step
+    game._cd("..")
+    game._cd("..")
+    game._cd("dream")
+    game._cd("npc")
+    inputs = iter(["1", "1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("dreamer")
+    capsys.readouterr()
+
+    # mentor step
+    game._cd("..")
+    game._cd("..")
+    game._cd("core")
+    game._cd("npc")
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("mentor")
+    capsys.readouterr()
+
+    # guardian step
+    game._cd("..")
+    game._cd("..")
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cd("runtime")
+    game._cd("npc")
+    inputs = iter(["1", "1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("guardian")
+    game._talk("guardian")
+    capsys.readouterr()
+
+    # all quest steps should now be cleared
+    assert all(q not in game.quests for q in [
+        "Seek the dreamer",
+        "Train with the mentor",
+        "Gain the guardian's approval",
+    ])


### PR DESCRIPTION
## Summary
- increase coverage of the `give` command
- add quest chain completion test
- test daemon trust-gated dialog branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562d8b3868832abf9dc2482f93150e