### PR TITLE
Update docs for quests and give command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ unexpected ways.
 
    **Core commands**
    - `look [dir]` / `look around` – describe the current room or a subdirectory
-  - `take <item>` / `drop <item>` / `give <item>` – manage or hand over inventory items
+  - `take <item>` / `drop <item>` / `give <item>` – manage inventory and hand requested items to NPCs
    - `inventory` / `i` / `inv` – show what you're carrying
    - `examine <item>` – get a closer look at an object
   - `use <item> [on <target>]` – interact with items (e.g. `use access.key on door` reveals hidden areas)
@@ -50,6 +50,7 @@ unexpected ways.
   - `man <command>` – show the manual page for a command
   - `journal` – view notes or `journal add <text>` to record a message
   - `quest` – list quests or `quest add <text>` / `quest complete <id>`
+    (quests can span multiple NPCs and progress through item exchanges)
   - `sleep [reset|inc]` – fall asleep and enter the dream. Use `reset` to
     clear glitches or `inc` to deepen them
   - `score` – display your current score
@@ -152,6 +153,11 @@ Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.
 The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
 NPC located under ``dream/oracle/``.
+
+Cross-NPC quests let conversations hand off objectives between characters. An
+NPC might ask you to deliver an item or speak with someone else before they
+reveal more dialog. Use ``give <item>`` after talking to them to hand over what
+they want and progress the shared quest chain.
 
 ## Plugins
 See [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md) for a full guide on creating and loading plugins.

--- a/VISIONDOCUMENT.md
+++ b/VISIONDOCUMENT.md
@@ -98,7 +98,9 @@ Endings include:
 
 The world now includes optional side quests and branching conversations with NPCs.
 Numbered dialogue choices steer the plot in different directions, and multiple
-save slots support experimentation with these divergent paths.
+save slots support experimentation with these divergent paths. Some quests span
+several NPCs, requiring you to deliver items and build trust using the new
+`give` command before further dialog unlocks.
 
 ---
 

--- a/docs/NPC_DIALOG.md
+++ b/docs/NPC_DIALOG.md
@@ -9,6 +9,8 @@ Lines beginning with `>` are presented to the player as numbered options. The se
 > Ask about escape [+curious]
 > Demand access [-polite]
 > Pick a style [style=quiet]
+> Offer assistance [trust+=1]
+> Discuss the archives [give=flashback.log;trust+=1]
 ```
 
 - `+flag` sets `flag` to `true`.
@@ -16,8 +18,9 @@ Lines beginning with `>` are presented to the player as numbered options. The se
 - `flag` without a prefix also sets the flag to `true`.
 - `flag=value` stores an arbitrary value.
 - `give=item` shows the choice only after the item was given with the `give` command.
+- `trust+=1` adds to a numeric trust counter used to unlock later dialog.
 
-Use the in-game `give` command after speaking with an NPC to hand over the requested item. Subsequent dialog can reference this item using the `[give=item]` directive on choices.
+Use the in-game `give` command after speaking with an NPC to hand over the requested item. Subsequent dialog can reference this item using the `[give=item]` directive on choices. You can also increase rapport with `[trust+=1]` to reveal new lines over multiple conversations.
 
 ## Conditional lines
 Lines starting with `?` show text only when a flag condition is met. Prefix the flag with `!` to invert the check.


### PR DESCRIPTION
## Summary
- document new `give` command in README
- describe cross-NPC quest chains
- add examples for `trust+=1` and `[give=item]` dialog directives
- mention the new mechanics in the vision document

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562ece3384832ab81545c140e0e9b1