### PR TITLE
Enhance opening description and update tests

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -1,6 +1,6 @@
 {
   "fs": {
-    "desc": "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently.",
+    "desc": "You find yourself in a dimly lit terminal session. Echoes of phantom keystrokes bounce around you and the flickering cursor threatens to disappear. A wave of unease washes over as you try to get your bearings. A closed door stands to one side, ominous yet strangely inviting, hinting that danger might lurk beyond it. The prompt blinks patiently.",
     "items": [
       "access.key",
       "voice.log",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -400,7 +400,7 @@ def test_cat_treasure_after_unlock():
 
 
 def test_glitch_mode_toggle():
-    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
+    normal = Game()._base_root_desc
     first_glitch = Game()._glitch_text(normal, 1)
     result = subprocess.run(
         CMD,
@@ -416,7 +416,7 @@ def test_glitch_mode_toggle():
 
 
 def test_glitch_persistence():
-    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
+    normal = Game()._base_root_desc
     first_glitch = Game()._glitch_text(normal, 1)
     later_glitch = Game()._glitch_text(normal, 3)
     result = subprocess.run(
@@ -433,7 +433,7 @@ def test_glitch_persistence():
 
 
 def test_glitch_intensity_increases():
-    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
+    normal = Game()._base_root_desc
     step1 = Game()._glitch_text(normal, 1)
     step3 = Game()._glitch_text(normal, 3)
     step5 = Game()._glitch_text(normal, 5)
@@ -712,7 +712,7 @@ def test_save_slots_independent(tmp_path):
 
 
 def test_glitch_save_and_load(tmp_path):
-    normal = "You find yourself in a dimly lit terminal session. A closed door stands to one side. The prompt blinks patiently."
+    normal = Game()._base_root_desc
     step4 = Game()._glitch_text(normal, 4)
 
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- expand starting area description in `world.json`
- make glitch text tests pull root description from the game object

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685630c94560832a96ea3be84fa5941c