### PR TITLE
Add glitch hallucination milestones

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -432,6 +432,16 @@ class Game:
     def _apply_glitch_effects(self) -> None:
         """Mutate the filesystem when glitch intensity crosses thresholds."""
         root_items = self.fs.setdefault("items", [])
+        if self.glitch_steps == 12:
+            self._output(
+                "For a split second a directory named 'beyond/' blinks into existence then fades."
+            )
+            self.glitch_steps -= 1
+        if self.glitch_steps == 18:
+            self._output(
+                "A phantom file 'escape.exe' materializes before dissolving back into nothingness."
+            )
+            self.glitch_steps -= 1
         if self.glitch_steps >= 5 and "glitch.note" not in root_items:
             root_items.append("glitch.note")
             self.item_descriptions["glitch.note"] = "A fragment of corrupted data."

--- a/tests/test_glitched_dialog.py
+++ b/tests/test_glitched_dialog.py
@@ -28,3 +28,37 @@ def test_dreamer_dialog_glitched():
         capture_output=True,
     )
     assert expected in result.stdout
+
+
+def test_glitch_milestone_12_message(capsys):
+    from escape import Game
+
+    game = Game()
+    game.glitch_mode = True
+    for _ in range(11):
+        game._output('tick')
+    capsys.readouterr()
+    game._output('tick')
+    out = capsys.readouterr().out
+    expected = game._glitch_text(
+        "For a split second a directory named 'beyond/' blinks into existence then fades.",
+        13,
+    )
+    assert expected in out
+
+
+def test_glitch_milestone_18_message(capsys):
+    from escape import Game
+
+    game = Game()
+    game.glitch_mode = True
+    for _ in range(17):
+        game._output('tick')
+    capsys.readouterr()
+    game._output('tick')
+    out = capsys.readouterr().out
+    expected = game._glitch_text(
+        "A phantom file 'escape.exe' materializes before dissolving back into nothingness.",
+        19,
+    )
+    assert expected in out


### PR DESCRIPTION
## Summary
- trigger hallucination messages at glitch steps 12 and 18
- print short narrative snippets when crossing these thresholds
- test new messages in glitch dialog tests

## Testing
- `pytest tests/test_glitched_dialog.py::test_glitch_milestone_12_message -q`
- `pytest tests/test_glitched_dialog.py::test_glitch_milestone_18_message -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685631944284832a98163b0d616bfd4c