### PR TITLE
Add emotional state feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,9 @@ state when using the ``save`` and ``load`` commands. Inside the game you can run
 the ``achievements`` command to display any that have been unlocked.
 See [docs/GAME_MECHANICS.md](docs/GAME_MECHANICS.md) for details on scoring and
 the restart command.
+
+## Emotional Feedback
+Reading certain memory logs now changes your avatar's mood. The current
+`emotion_state` starts as `confused` and may become `alarmed` or `hopeful`
+when key memories surface. Whenever this state changes a short thought like
+`(You feel hopeful.)` is printed before the next line of output.

--- a/escape/game.py
+++ b/escape/game.py
@@ -88,6 +88,11 @@ class Game:
         self.glitch_mode = False
         self.glitch_steps = 0
 
+        # emotional state tracking
+        self.emotion_state = "confused"
+        self._prev_emotion_state = self.emotion_state
+        self._memory_emotions = {"memory8.log": "alarmed", "memory11.log": "hopeful"}
+
         # store all commands the player enters this session
         self.command_history: list[str] = []
 
@@ -406,6 +411,9 @@ class Game:
 
     def _output(self, text: str = "") -> None:
         """Print text, applying glitch effects when enabled."""
+        if self.emotion_state != self._prev_emotion_state:
+            print(f"(You feel {self.emotion_state}.)")
+            self._prev_emotion_state = self.emotion_state
         if self.glitch_mode and text:
             self.glitch_steps += 1
             text = self._glitch_text(text, self.glitch_steps)
@@ -747,6 +755,8 @@ class Game:
         except OSError as e:
             self._output(f"Failed to read {filename}: {e}")
             return
+        if filename in self._memory_emotions:
+            self.emotion_state = self._memory_emotions[filename]
         if filename == "runtime.log":
             env_lines = []
             for key, val in os.environ.items():


### PR DESCRIPTION
## Summary
- track a simple emotion state in `Game`
- update emotion when reading certain memory logs
- print a short internal thought when the emotion changes
- document emotional feedback in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685633358198832aad64a82e3754d421