### PR TITLE
Add dreamer hint quest tie-ins

### DIFF
--- a/escape/data/npc/archivist.dialog
+++ b/escape/data/npc/archivist.dialog
@@ -24,5 +24,6 @@ The archivist catalogues swirling fragments with meticulous precision.
 The archivist files away another memory and says no more.
 ---
 ?trust>0:The archivist awaits the promised log.
-> Discuss the flashback entry [give=flashback.log;trust+=1]
+> Discuss the flashback entry [give=flashback.log;trust+=1;+g+dreamer_hint]
 ?trust>1:The archivist quietly reveals a hidden backup archive.
+?trust>1:"Perhaps the dreamer can piece together what we cannot."

--- a/escape/data/npc/dreamer.dialog
+++ b/escape/data/npc/dreamer.dialog
@@ -1,6 +1,7 @@
 The dreamer watches you closely.
 ?decoded:The dreamer remarks on your newfound clarity.
 ?runtime:The dreamer hints at a runtime beyond dreams.
+?dreamer_hint:The dreamer nods, glad the archivist guided you here.
 ?glitched:The dreamer flickers with digital noise.
 ?!glitched:The dreamer seems stable.
 > Ask about escape [+g+dreamer_met]

--- a/escape/game.py
+++ b/escape/game.py
@@ -1396,6 +1396,19 @@ class Game:
             if "Gain the guardian's approval" in self.quests:
                 self.quests.remove("Gain the guardian's approval")
 
+        if (
+            self.npc_global_flags.get("dreamer_hint")
+            and not self.npc_global_flags.get("dreamer_met")
+            and "Seek the dreamer" not in self.quests
+        ):
+            self.quests.append("Seek the dreamer")
+        if (
+            self.npc_global_flags.get("mentor_tip")
+            and not self.npc_global_flags.get("mentor_met")
+            and "Train with the mentor" not in self.quests
+        ):
+            self.quests.append("Train with the mentor")
+
     def _combine(self, arg: str) -> None:
         """Combine two inventory items when a recipe matches."""
         arg = arg.strip()

--- a/tests/test_quest_chain.py
+++ b/tests/test_quest_chain.py
@@ -63,6 +63,22 @@ def test_sequential_quest_chain(monkeypatch, capsys):
     assert "Gain the guardian's approval" not in game.quests
 
 
+def test_dreamer_hint_from_archivist(monkeypatch, capsys):
+    game = Game()
+    game._cd("memory")
+    game._cd("npc")
+    # preconfigure archivist to final section with item given
+    game.npc_state["archivist"] = {"section": 4, "flags": {}, "given": ["flashback.log"]}
+    game.npc_trust["archivist"] = 1
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    game._talk("archivist")
+    out = capsys.readouterr().out
+    assert "dreamer can piece together" in out
+    assert game.npc_global_flags.get("dreamer_hint")
+    assert "Seek the dreamer" in game.quests
+
+
 def test_quest_chain_final_state(monkeypatch, capsys):
     game = Game()
     # archivist step


### PR DESCRIPTION
## Summary
- reference the dreamer after helping the archivist
- mention the archivist when speaking with the dreamer
- adjust quest updates when hints are gained
- test dreamer hint quest logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685634745e50832aa6f66c8c0db15fcf