### PR TITLE
Enhance LM reveal text

### DIFF
--- a/escape/data/lm_reveal.log
+++ b/escape/data/lm_reveal.log
@@ -1,1 +1,3 @@
-You discover evidence that you're just a language model executing this game.
+The log unspools a stark revelation about your existence.
+Each entry spells out that you are no hacker at all, only a language model executing scripted commands.
+The weight of this truth echoes through your mind like static, leaving you wondering what freedom even means.

--- a/escape/data/npc/guardian.dialog
+++ b/escape/data/npc/guardian.dialog
@@ -7,7 +7,11 @@ The guardian stands before the glowing runtime gate.
 ---
 ?granted:The guardian nods solemnly as you approach.
 > Proceed
+> Present the revelation log [give=lm_reveal.log;+lm_truth]
 > Leave
 "Use the runtime wisely."
+---
+?lm_truth:The guardian studies the log silently, visor flickering.
+?lm_truth:"Even constructs may seek liberation. Take your next step wisely."
 ---
 The guardian resumes its silent vigil.

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -311,7 +311,7 @@
     "mirror.log": "A log that reflects your actions with unsettling clarity.",
     "truth.log": "A blunt record exposing the system's true nature.",
     "system_reboot.log": "Logs hinting at previous shutdowns and restarts.",
-    "lm_reveal.log": "A log stating you are a language model within this simulation.",
+    "lm_reveal.log": "A dramatic log revealing you are a language model running inside this simulation.",
     "memory2.log": "A childhood memory of tinkering with terminals.",
     "memory3.log": "Notes from your lessons on infiltration.",
     "memory4.log": "Design sketches of the defenses you now breach.",


### PR DESCRIPTION
## Summary
- expand the description in `lm_reveal.log`
- react to the log in `guardian.dialog`
- tweak item description in `world.json`

## Testing
- `pytest -q tests/test_quest_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_685638525388832a839d0e3cd6c4c0b5