### PR TITLE
Remove tracked dist-info directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 wheels/
 share/python-wheels/
 *.egg-info/
+*.dist-info/
 .installed.cfg
 *.egg
 MANIFEST

--- a/escape_the_terminal-0.1.0.dist-info/METADATA
+++ b/escape_the_terminal-0.1.0.dist-info/METADATA
@@ -1,3 +1,0 @@
-Metadata-Version: 2.1
-Name: escape-the-terminal
-Version: 0.1.0

--- a/escape_the_terminal-0.1.0.dist-info/entry_points.txt
+++ b/escape_the_terminal-0.1.0.dist-info/entry_points.txt
@@ -1,2 +1,0 @@
-[console_scripts]
-escape-terminal = escape.cli:main


### PR DESCRIPTION
## Summary
- ignore Python `*.dist-info/` metadata directories
- remove previously committed `escape_the_terminal-0.1.0.dist-info`

## Testing
- `pip install -e '.[test]'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68564c47a21c832a8b3b2d12ad9a9421