### PR TITLE
Add flake8 step and style fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[test]'
+          pip install flake8
       - name: Run tests
         run: |
           pytest -q
+      - name: Run flake8
+        run: |
+          python -m flake8 escape
 
   dialog-validation:
     runs-on: ubuntu-latest

--- a/escape/cli.py
+++ b/escape/cli.py
@@ -57,4 +57,3 @@ def main(argv: list[str] | None = None):
 
     game_color = True if args.color else None
     Game(use_color=game_color, world_file=args.world, prompt=args.prompt).run()
-

--- a/escape/game.py
+++ b/escape/game.py
@@ -266,14 +266,14 @@ class Game:
         count = rnd.randint(3, 5)
         files: list[str] = []
         for i in range(count):
-            fname = f"system_{rnd.randint(1000,9999)}.log"
+            fname = f"system_{rnd.randint(1000, 9999)}.log"
             files.append(fname)
             lines = [
                 f"INFO iteration {i}",
                 (
                     "SYSTEM BOOT COMPLETE"
                     if i == 0
-                    else f"DEBUG value {rnd.randint(0,100)}"
+                    else f"DEBUG value {rnd.randint(0, 100)}"
                 ),
             ]
             with open(self.logs_path / fname, "w", encoding="utf-8") as f:

--- a/escape/plugins/counter.py
+++ b/escape/plugins/counter.py
@@ -1,17 +1,22 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
 
 if TYPE_CHECKING:
     from escape import Game
 
-    game: Game
+game: Optional[Game] = globals().get("game")
+
 
 counter_value = 0
+
 
 def counter(arg=""):
     """Increment and display a counter value."""
     global counter_value
     counter_value += 1
     game._output(f"Counter: {counter_value}")
+
 
 if 'game' in globals():
     game.command_map['counter'] = lambda arg="": counter(arg)

--- a/escape/plugins/dance.py
+++ b/escape/plugins/dance.py
@@ -1,14 +1,17 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
 
 if TYPE_CHECKING:
     from escape import Game
 
-    game: Game
+game: Optional[Game] = globals().get("game")
 
 
 def dance(arg=""):
     """Print a playful dance message."""
     game._output(f"Dancing {arg}" if arg else "Dancing")
+
 
 # register the command on import
 if 'game' in globals():

--- a/escape/plugins/puzzle.py
+++ b/escape/plugins/puzzle.py
@@ -1,14 +1,19 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
 
 if TYPE_CHECKING:
     from escape import Game
 
-    game: Game
+game: Optional[Game] = globals().get("game")
+
 
 puzzle_solved = False
 
+
 _encoded_msg = "Uifsf jt b tfdsfu nfttbhf."
 _answer = "there is a secret message."
+
 
 def puzzle(arg: str = "") -> None:
     """Small code-breaking challenge."""

--- a/escape/plugins/riddle.py
+++ b/escape/plugins/riddle.py
@@ -1,9 +1,12 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
 
 if TYPE_CHECKING:
     from escape import Game
 
-    game: Game
+game: Optional[Game] = globals().get("game")
+
 
 riddle_shown = False
 _riddle = "What has to be broken before you can use it?"

--- a/escape/plugins/theme.py
+++ b/escape/plugins/theme.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
+
 
 if TYPE_CHECKING:
     from escape import Game
 
-    game: Game
+game: Optional[Game] = globals().get("game")
 
 
 THEMES = {
     'dark': ("\x1b[34m", "\x1b[35m"),  # blue directories, magenta items
     'mono': ("\x1b[37m", "\x1b[37m"),  # white directories and items
-    'neon': ("\x1b[92m", "\x1b[95m"),  # bright green dirs, bright magenta items
+    'neon': ("\x1b[92m", "\x1b[95m"),  # bright green dirs, magenta items
 }
 
 


### PR DESCRIPTION
## Summary
- run flake8 in CI
- configure repo flake8 line length
- adjust plugin modules to satisfy flake8
- fix minor lint issues

## Testing
- `pytest -q`
- `python -m flake8 escape`

------
https://chatgpt.com/codex/tasks/task_e_68564db633e4832ab0c1cf46a51c88df