### PR TITLE
Fix flake8 lint failure in filesystem module

### DIFF
--- a/escape/filesystem.py
+++ b/escape/filesystem.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints


### PR DESCRIPTION
## Summary
- remove an unused import from `filesystem.py`

## Testing
- `pytest -q`
- `python -m flake8 escape`

------
https://chatgpt.com/codex/tasks/task_e_6856562980d0832a82eaf1c617722f45