### PR TITLE
Add technomancer NPC in dream tech lab

### DIFF
--- a/escape/data/npc/technomancer.dialog
+++ b/escape/data/npc/technomancer.dialog
@@ -1,0 +1,19 @@
+The technomancer calibrates humming interfaces.
+?decoded:The technomancer notes the power in your fragment.
+?runtime:The technomancer grins at your runtime tweaks.
+> Inquire about glitches [+glitch_tips;journal=The technomancer shared layering glitches.]
+> Ask about the lab
+> Leave
+"Mastery lies in bending the system's routines."
+?glitch_tips:"Layer glitches to breach deeper security."
+---
+?glitch_tips:The technomancer demonstrates a cascading glitch pattern.
+?!glitch_tips:The technomancer waits for you to experiment.
+> Request advanced guidance [+advanced]
+> Step away
+?advanced:"Combine timing loops with glitch for greater effect."
+"Experiment until reality shivers."
+---
+?advanced:The technomancer warns against losing yourself in the code.
+?!advanced:The technomancer focuses on glowing monitors.
+"May your glitches reveal the path."

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -71,6 +71,11 @@
             "desc": "A shimmering path bridging memory and dream.",
             "items": [],
             "dirs": {}
+          },
+          "tech_lab": {
+            "desc": "A high-tech lab humming with experimental energy.",
+            "items": [],
+            "dirs": {}
           }
         }
       },
@@ -266,6 +271,10 @@
     "sandboxer": [
       "sandbox",
       "npc"
+    ],
+    "technomancer": [
+      "dream",
+      "tech_lab"
     ],
     "guardian": [
       "deep_network_node",

--- a/tests/test_npc_technomancer.py
+++ b/tests/test_npc_technomancer.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+CMD = [sys.executable, '-m', 'escape']
+
+
+def test_technomancer_dialog():
+    result = subprocess.run(
+        CMD,
+        input='cd dream\ncd tech_lab\ntalk technomancer\n1\ntalk technomancer\n1\nquit\n',
+        text=True,
+        capture_output=True,
+    )
+    out = result.stdout
+    assert 'technomancer calibrates' in out
+    assert '1. Inquire about glitches' in out
+    assert 'Layer glitches to breach deeper security' in out
+    assert 'Combine timing loops with glitch' in out
+    assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- expand `dream` with `tech_lab` directory
- place new `technomancer` NPC in `dream/tech_lab`
- create dialog for technomancer
- test the technomancer dialog path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685658e29aac832ab72796435f771686