### PR TITLE
Add weather plugin

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -91,3 +91,7 @@ A second bundled plugin named `puzzle.py` offers a small code-breaking riddle. R
 ## Built-in Riddle Plugin
 
 The `riddle.py` module presents a short question the first time you run `riddle`. Run the command again with your guess and it will tell you if you are correct.
+
+## Built-in Weather Plugin
+
+The `weather.py` plugin prints a random short forecast whenever you run `weather`.

--- a/escape/plugins/weather.py
+++ b/escape/plugins/weather.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+import random
+
+if TYPE_CHECKING:
+    from escape import Game
+
+game: Optional[Game] = globals().get("game")
+
+weather_messages = [
+    "Clear skies all around.",
+    "A gentle rain begins to fall.",
+    "Thunder rumbles in the distance.",
+    "A dense fog settles over the area.",
+]
+
+
+def weather(arg: str = "") -> None:
+    """Print a random weather description."""
+    msg = random.choice(weather_messages)
+    game._output(msg)
+
+
+if 'game' in globals():
+    game.command_map['weather'] = lambda arg="": weather(arg)

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1,0 +1,15 @@
+from escape import Game
+
+
+def test_weather_plugin(monkeypatch, capsys):
+    game = Game()
+    from escape.plugins import weather
+    assert 'weather' in game.command_map
+    monkeypatch.setattr(weather.random, 'choice', lambda seq: seq[0])
+    inputs = iter(['weather', 'quit'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out = capsys.readouterr().out
+    assert weather.weather_messages[0] in out
+    assert 'Goodbye' in out
+


### PR DESCRIPTION
## Summary
- add a new weather plugin that prints a random forecast
- document how to use the weather plugin
- test the weather command

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565a7bc4fc832aa4916172524fe5cc