### PR TITLE
Add void quest after using loop.code

### DIFF
--- a/escape/data/void/npc/wanderer.dialog
+++ b/escape/data/void/npc/wanderer.dialog
@@ -1,0 +1,3 @@
+The wanderer stands amid the void, shaken by endless loops.
+"The cycle reset, but this place remained..."
+"Maybe here we can find a new path."

--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -118,6 +118,20 @@
           "truth.log"
         ],
         "dirs": {}
+      },
+      "void": {
+        "desc": "A desolate space lingering after recursion.",
+        "items": [
+          "void.log"
+        ],
+        "dirs": {
+          "npc": {
+            "desc": "A hidden corner where a wanderer waits.",
+            "items": [],
+            "dirs": {}
+          }
+        },
+        "locked": true
       }
     }
   },
@@ -332,6 +346,7 @@
     "memory10.log": "Records of wiping your own identity.",
     "memory11.log": "Proof you triggered the escape protocol.",
     "memory12.log": "The last memory before reaching the runtime.",
+    "void.log": "A bleak record written outside normal memory.",
     "guardian.key": "A special key required to breach the final node."
   },
   "recipes": {

--- a/escape/game.py
+++ b/escape/game.py
@@ -516,6 +516,12 @@ class Game:
             self._output("Loop")
             self.score += 1
             self._restart()
+            # after restarting, mark that the loop was triggered and unlock the void
+            self.npc_global_flags["loop_used"] = True
+            void_dir = self.fs.get("dirs", {}).get("void")
+            if isinstance(void_dir, dict):
+                void_dir.pop("locked", None)
+            self.npc_locations["wanderer"] = ["void", "npc"]
             return
         if item == "access.key" and (target == "door" or target is None):
             root = self.fs

--- a/escape/npc.py
+++ b/escape/npc.py
@@ -38,6 +38,9 @@ def update_quests_after_talk(game: "Game", npc: str) -> None:
     ):
         game.quests.append("Train with the mentor")
 
+    if game.npc_global_flags.get("loop_used") and "Explore the void" not in game.quests:
+        game.quests.append("Explore the void")
+
 
 def talk(game: "Game", npc: str) -> None:
     """Converse with an NPC if present in the current directory."""
@@ -48,7 +51,10 @@ def talk(game: "Game", npc: str) -> None:
 
     game.active_npc = npc
 
-    dialog_file = game.data_dir / "npc" / f"{npc}.dialog"
+    path_parts = list(location) + [f"{npc}.dialog"] if location else []
+    dialog_file = game.data_dir.joinpath(*path_parts)
+    if not dialog_file.exists():
+        dialog_file = game.data_dir / "npc" / f"{npc}.dialog"
     try:
         raw_lines = dialog_file.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:

--- a/tests/test_void_quest.py
+++ b/tests/test_void_quest.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, REPO_ROOT)
+
+from escape import Game
+
+
+def setup_runtime(game: Game) -> None:
+    game.fs.setdefault("dirs", {})["runtime"] = {
+        "desc": "Test runtime",
+        "items": ["runtime.log", "lm_reveal.log"],
+        "dirs": {},
+        "locked": True,
+    }
+    game.inventory.extend(["port.scanner", "auth.token", "kernel.key"])
+
+
+def use_loop_code(game: Game, capsys) -> None:
+    setup_runtime(game)
+    game._hack("runtime")
+    capsys.readouterr()
+    game._cd("runtime")
+    game._take("loop.code")
+    capsys.readouterr()
+    game._use("loop.code")
+    capsys.readouterr()
+
+
+def test_loop_code_unlocks_void(monkeypatch, capsys):
+    game = Game()
+    use_loop_code(game, capsys)
+    assert "void" in game.fs["dirs"]
+    assert "locked" not in game.fs["dirs"]["void"]
+    assert game.npc_locations["wanderer"] == ["void", "npc"]
+    game._cd("void")
+    game._cd("npc")
+    game._talk("wanderer")
+    out = capsys.readouterr().out
+    assert "void" in out
+    assert "Explore the void" in game.quests


### PR DESCRIPTION
## Summary
- add a hidden `void` directory in the game world
- unlock the void after `loop.code` is used and move wanderer there
- trigger an "Explore the void" quest when any NPC is talked to after looping
- support location-specific NPC dialog
- provide new wanderer dialog and regression tests

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68565bdf060c832ab49d565734df04ed