### PR TITLE
Add cipher plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,12 @@ others.
 
 The repository includes a few example plugins that are loaded automatically.
 Run ``theme dark`` or ``theme neon`` to change the directory and item colors at
-runtime, or try ``puzzle`` to solve a short encoded riddle.
+runtime, or try ``puzzle`` and ``cipher`` to solve short encoded riddles.
+
+Example ``cipher`` usage::
+
+    cipher
+    cipher You found a secret decoder.
 
 ## Custom Worlds
 The starting filesystem, NPC locations and item descriptions are defined in

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -88,6 +88,10 @@ directory and item colors explicitly.
 
 A second bundled plugin named `puzzle.py` offers a small code-breaking riddle. Run `puzzle` without arguments to see the encoded phrase and pass your decoded answer to solve it. The module remembers if you solved the puzzle so subsequent runs simply report that it is already complete.
 
+## Built-in Cipher Plugin
+
+The `cipher.py` plugin presents a short ROT13 message. Run `cipher` to display the scrambled text and supply the decoded phrase to complete the challenge.
+
 ## Built-in Riddle Plugin
 
 The `riddle.py` module presents a short question the first time you run `riddle`. Run the command again with your guess and it will tell you if you are correct.

--- a/escape/plugins/cipher.py
+++ b/escape/plugins/cipher.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from escape import Game
+
+# game instance injected by Game._load_plugins
+game: Optional[Game] = globals().get("game")
+
+_cipher_solved = False
+_encoded_msg = "Lbh sbhaq n frperg qrpvqre."
+_answer = "you found a secret decoder."
+
+
+def cipher(arg: str = "") -> None:
+    """Decode the ROT13 message to solve the puzzle."""
+    global _cipher_solved
+    guess = arg.strip().lower()
+    if _cipher_solved:
+        game._output("Cipher already solved.")
+        return
+    if not guess:
+        game._output(f"Decode this: {_encoded_msg}")
+        return
+    if guess == _answer:
+        _cipher_solved = True
+        game._output("Correct! Cipher solved.")
+    else:
+        game._output("Incorrect. Try again.")
+
+
+if 'game' in globals():
+    game.command_map['cipher'] = lambda arg="": cipher(arg)

--- a/tests/test_cipher_plugin.py
+++ b/tests/test_cipher_plugin.py
@@ -1,0 +1,15 @@
+from escape import Game
+
+
+def test_cipher_plugin(monkeypatch, capsys):
+    game = Game()
+    inputs = iter([
+        'cipher',
+        'cipher You found a secret decoder.',
+        'quit',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game.run()
+    out_lines = capsys.readouterr().out.splitlines()
+    assert any('Decode this:' in line for line in out_lines)
+    assert 'Correct! Cipher solved.' in out_lines

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -183,5 +183,6 @@ def test_plugins_command_lists_builtins(monkeypatch, capsys):
         'escape.plugins.puzzle',
         'escape.plugins.theme',
         'escape.plugins.riddle',
+        'escape.plugins.cipher',
     }
     assert expected.issubset(set(out_lines))


### PR DESCRIPTION
## Summary
- implement builtin cipher plugin
- document new plugin in README and plugin development guide
- test plugin and update plugin list

## Testing
- `pytest -q tests/test_cipher_plugin.py tests/test_plugins.py::test_plugins_command_lists_builtins`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565e8fd69c832abf6a1b4377614227