### PR TITLE
Add glitch step to tutorial

### DIFF
--- a/escape/data/man/tutorial.man
+++ b/escape/data/man/tutorial.man
@@ -1,3 +1,3 @@
-tutorial - Guided introduction to core commands
+tutorial - Guided introduction to core commands and glitch mode
 Usage: tutorial
 Example: tutorial

--- a/escape/game.py
+++ b/escape/game.py
@@ -828,11 +828,13 @@ class Game:
         moved = bool(self.current)
         looked = any(cmd.split()[0] == "look" for cmd in self.command_history)
         took_item = bool(self.inventory)
+        glitched = any(cmd.split()[0] == "glitch" for cmd in self.command_history)
         self._output("Tutorial:")
         steps = [
             ("Move using 'cd <dir>'", moved),
             ("Look around with 'look'", looked),
             ("Take an item with 'take <item>'", took_item),
+            ("Toggle 'glitch' to distort reality", glitched),
         ]
         for idx, (text, done) in enumerate(steps, 1):
             mark = "[x]" if done else "[ ]"

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -15,4 +15,5 @@ def test_tutorial_outputs_steps(monkeypatch, capsys):
     assert 'Tutorial:' in out
     assert 'Move using' in out
     assert 'Take an item' in out
+    assert 'glitch' in out
     assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- teach players about `glitch` in the tutorial
- document glitch mode in the `tutorial` man page
- test tutorial output for glitch info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565fd282d4832aacb812643db6dbf7