### PR TITLE
Improve docs and tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ unexpected ways.
   - `daemon.log` – consult the system daemon when read or used, found in `core/npc/`
   - `escape.code` – the deciphered sequence unlocked within the vault
   - `port.scanner` – enables hacking of network nodes, found in the `lab/`
+  - `loop.code` – resets reality and unlocks the optional void quest
   - `test.script` – an experimental file tucked away in the `sandbox/` directory
 
    **Rooms**
@@ -81,6 +82,7 @@ unexpected ways.
   - `sandbox/` – an isolated test area for trying new commands
   - `sandbox/npc/` – meet the sandboxer for tips on experimentation
   - `dream/oracle/` – an enigmatic hall where the oracle offers cryptic advice
+  - `dream/tech_lab/` – home to the technomancer and advanced glitch research
 
 ## Running Tests
 Tests are written with `pytest` and live under the `tests/` directory. After installing
@@ -153,12 +155,16 @@ the CI workflow.
 Modders can create additional files following this pattern and place their NPCs
 in the game world by extending ``Game.npc_locations``.
 The provided ``oracle.dialog`` shows a multi-stage conversation for an oracle
-NPC located under ``dream/oracle/``.
+NPC located under ``dream/oracle/``. A more experimental Technomancer can be
+found within ``dream/tech_lab/``.
 
 Cross-NPC quests let conversations hand off objectives between characters. An
 NPC might ask you to deliver an item or speak with someone else before they
 reveal more dialog. Use ``give <item>`` after talking to them to hand over what
 they want and progress the shared quest chain.
+
+Triggering the ``loop.code`` found in the runtime directory restarts the world
+and unlocks a hidden ``void`` area where the wanderer offers additional insight.
 
 ## Plugins
 See [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md) for a full guide on creating and loading plugins.
@@ -208,7 +214,8 @@ others.
 
 The repository includes a few example plugins that are loaded automatically.
 Run ``theme dark`` or ``theme neon`` to change the directory and item colors at
-runtime, or try ``puzzle`` and ``cipher`` to solve short encoded riddles.
+runtime, or try ``puzzle``, ``cipher``, ``riddle`` or ``weather`` for small
+interactive extras.
 
 Example ``cipher`` usage::
 

--- a/escape/data/man/cipher.man
+++ b/escape/data/man/cipher.man
@@ -1,0 +1,3 @@
+cipher - Decode a short ROT13 message
+Usage: cipher [answer]
+Example: cipher hello

--- a/escape/data/man/puzzle.man
+++ b/escape/data/man/puzzle.man
@@ -1,0 +1,3 @@
+puzzle - Solve an encoded message
+Usage: puzzle [answer]
+Example: puzzle Secret phrase

--- a/escape/data/man/riddle.man
+++ b/escape/data/man/riddle.man
@@ -1,0 +1,3 @@
+riddle - Answer a simple question
+Usage: riddle [answer]
+Example: riddle egg

--- a/escape/data/man/weather.man
+++ b/escape/data/man/weather.man
@@ -1,0 +1,3 @@
+weather - Show a random weather forecast
+Usage: weather
+Example: weather

--- a/escape/data/void/npc/wanderer.dialog
+++ b/escape/data/void/npc/wanderer.dialog
@@ -1,3 +1,5 @@
 The wanderer stands amid the void, shaken by endless loops.
 "The cycle reset, but this place remained..."
 "Maybe here we can find a new path."
+"The wanderer reflects on your persistence."
+"Together you glimpse a route beyond the void."

--- a/escape/game.py
+++ b/escape/game.py
@@ -835,6 +835,8 @@ class Game:
             ("Look around with 'look'", looked),
             ("Take an item with 'take <item>'", took_item),
             ("Toggle 'glitch' to distort reality", glitched),
+            ("Scan for nodes with 'scan <dir>'", any(cmd.split()[0] == "scan" for cmd in self.command_history)),
+            ("Hack nodes using 'hack <dir>'", any(cmd.split()[0] == "hack" for cmd in self.command_history)),
         ]
         for idx, (text, done) in enumerate(steps, 1):
             mark = "[x]" if done else "[ ]"

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -16,4 +16,6 @@ def test_tutorial_outputs_steps(monkeypatch, capsys):
     assert 'Move using' in out
     assert 'Take an item' in out
     assert 'glitch' in out
+    assert 'scan' in out
+    assert 'hack' in out
     assert 'Goodbye' in out


### PR DESCRIPTION
## Summary
- document technomancer location, weather plugin and void quest
- add manual pages for puzzle, cipher, riddle and weather commands
- extend wanderer epilogue dialog
- mention scan/hack steps in the tutorial
- test updated tutorial

## Testing
- `python -m pytest tests/test_tutorial.py tests/test_void_quest.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685661d737ac832a846132218c00bb70