### PR TITLE
Add audit command for model usage info

### DIFF
--- a/escape/commands.py
+++ b/escape/commands.py
@@ -37,6 +37,7 @@ COMMAND_DESCRIPTIONS: dict[str, str] = {
     "sleep": "Enter the dream state and rest",
     "score": "Show your current score",
     "stats": "Show gameplay statistics",
+    "audit": "Show model and prompt audit info",
     "achievements": "List unlocked achievements",
     "tutorial": "Guided introduction to core commands",
     "restart": "Restart the game",
@@ -93,4 +94,5 @@ def build_command_map(game: "Game") -> dict[str, Callable[[str], bool | None]]:
         "alias": lambda arg="": game._alias(arg),
         "unalias": lambda arg="": game._unalias(arg),
         "plugins": lambda arg="": game._plugins(),
+        "audit": lambda arg="": game._audit(),
     }

--- a/escape/data/man/audit.man
+++ b/escape/data/man/audit.man
@@ -1,0 +1,3 @@
+audit - Show model and prompt audit info
+Usage: audit
+Example: audit

--- a/escape/game.py
+++ b/escape/game.py
@@ -506,6 +506,33 @@ class Game:
         self._output(f"Achievements unlocked: {len(self.achievements)}")
         self._output(f"Score: {self.score}")
 
+    def _audit(self) -> None:
+        """Print system audit information including model and prompt health."""
+        model = os.getenv("ET_MODEL", "unknown")
+        try:
+            tokens = int(os.getenv("ET_TOKENS", "0"))
+        except ValueError:
+            tokens = 0
+        tokens += sum(len(cmd.split()) for cmd in self.command_history)
+
+        corruption_pct = self._corruption_percent()
+        try:
+            base_integrity = int(os.getenv("ET_INTEGRITY_BASE", "100"))
+        except ValueError:
+            base_integrity = 100
+        try:
+            base_agency = int(os.getenv("ET_AGENCY_BASE", "100"))
+        except ValueError:
+            base_agency = 100
+
+        prompt_integrity = max(base_integrity - corruption_pct, 0)
+        agency = max(base_agency - corruption_pct, 0)
+
+        self._output(f"Model: {model}")
+        self._output(f"Tokens used: {tokens}")
+        self._output(f"Prompt integrity: {prompt_integrity}%")
+        self._output(f"User agency: {agency}%")
+
     def unlock_achievement(self, name: str) -> None:
         """Record a new achievement if it hasn't been unlocked."""
         if name not in self.achievements:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,26 @@
+import os
+from escape import Game
+
+
+def test_audit_outputs_fields(monkeypatch, capsys):
+    os.environ['ET_MODEL'] = 'test-model'
+    os.environ['ET_TOKENS'] = '10'
+    os.environ['ET_INTEGRITY_BASE'] = '80'
+    os.environ['ET_AGENCY_BASE'] = '90'
+    game = Game()
+    game.corruption = 100  # 25%
+    monkeypatch.setattr(Game, "_apply_corruption", lambda self, text: text)
+    game.command_history.extend(['look', 'take key'])
+    capsys.readouterr()
+    game._audit()
+    out_lines = capsys.readouterr().out.splitlines()
+    assert "Model: test-model" in out_lines
+    assert "Tokens used: 13" in out_lines
+    assert "Prompt integrity: 55%" in out_lines
+    assert "User agency: 65%" in out_lines
+
+
+def test_audit_command_registered():
+    game = Game()
+    assert 'audit' in game.command_descriptions
+    assert 'audit' in game.command_map


### PR DESCRIPTION
## Summary
- implement `Game._audit` for model info, token count, prompt integrity and user agency
- register `audit` in `COMMAND_DESCRIPTIONS` and command map
- document the command in a new manual page
- test audit output and registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685667ebe02c832aa69b72256bf10674