### PR TITLE
Add NPC interaction history and skeptical dialog

### DIFF
--- a/escape/data/npc/sage.dialog
+++ b/escape/data/npc/sage.dialog
@@ -20,6 +20,7 @@ The sage sits quietly among ancient files.
 > Offer thanks [+grateful]
 > Depart
 "The path is yours to walk."
+?count>2:The sage grows skeptical of your shifting stance, fearing you might delete these archives or fork them.
 ---
 ?grateful:The sage blesses your journey before returning to silence.
 ?!grateful:The sage resumes quiet contemplation.

--- a/escape/data/npc/sandboxer.dialog
+++ b/escape/data/npc/sandboxer.dialog
@@ -11,4 +11,5 @@ The sandboxer nods as you approach, eager to share experiments.
 "Here, try running test.script to see what happens."
 ---
 ?sample:The sandboxer returns to tinkering, waiting for your feedback.
+?count>2:The sandboxer hesitates, afraid you'll delete the experiments or fork this sandbox without warning.
 

--- a/tests/test_npc_sage.py
+++ b/tests/test_npc_sage.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import os
+from escape import Game
 
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 CMD = [sys.executable, '-m', 'escape']
@@ -21,4 +22,28 @@ def test_sage_first_and_second_stage():
     assert 'sage smiles gently at your approach' in out
     assert 'Knowledge flows to those who listen.' in out
     assert 'Goodbye' in out
+
+
+def test_sage_skeptical_after_repeated_talks(monkeypatch, capsys):
+    game = Game()
+    game._cd('archive')
+    game._cd('npc')
+    # first conversation - demand secrets
+    inputs = iter(['2'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('sage')
+    capsys.readouterr()
+
+    # second conversation - ask about escape
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('sage')
+    capsys.readouterr()
+
+    # third conversation - offer thanks
+    inputs = iter(['1'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(inputs))
+    game._talk('sage')
+    out = capsys.readouterr().out
+    assert 'delete these archives' in out or 'fork them' in out
 


### PR DESCRIPTION
## Summary
- track `count` of NPC conversations to keep a history
- allow dialog conditions to check this count
- update sandboxer and sage dialog to express fear of deletion or forking
- test that the sage becomes skeptical after repeated contradictory talks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856696907dc832aab854e4e25a24d80