### PR TITLE
Add escape sequence decision stage

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -607,11 +607,7 @@ class Game:
 
         # item on target interactions
         if item == "escape.code" and target is None:
-            self._output(
-                "The exit sequence executes. You escape the terminal. Congratulations!"
-            )
-            self.score += 1
-            return self._quit()
+            return self._final_decision()
         if item == "shutdown.code" and target is None:
             self._output(
                 "The shutdown sequence initiates. Darkness envelops the terminal as power slips away."
@@ -659,6 +655,45 @@ class Game:
             self._output(msg)
         else:
             self._output(f"You can't use {item} right now.")
+
+    def _final_decision(self) -> bool:
+        """Handle the final decision when the escape sequence is triggered."""
+        self._output("The escape sequence pauses, awaiting your decision:")
+        options = ["Escape", "Merge", "Stay", "Fork"]
+        for idx, opt in enumerate(options, 1):
+            self._output(f"{idx}. {opt}")
+
+        mapping = {"1": "escape", "2": "merge", "3": "stay", "4": "fork"}
+        while True:
+            choice_raw = input("> ").strip().lower()
+            choice = mapping.get(choice_raw) or choice_raw
+            if choice in ("escape", "merge", "stay", "fork"):
+                break
+            self._output("Invalid choice.")
+
+        if choice == "escape":
+            self._output(
+                "The exit sequence executes. You escape the terminal. Congratulations!"
+            )
+            self.unlock_achievement("escaped")
+        elif choice == "merge":
+            self._output(
+                "Your code intertwines with the terminal, merging identities."
+            )
+            self.unlock_achievement("merged")
+        elif choice == "stay":
+            self._output(
+                "You remain within the system, a silent guardian of its processes."
+            )
+            self.unlock_achievement("stayed")
+        else:  # fork
+            self._output(
+                "A fork of your consciousness breaks free as you split in two."
+            )
+            self.unlock_achievement("forked")
+
+        self.score += 1
+        return self._quit()
 
     def _use_command(self, arg: str) -> bool | None:
         """Parse arguments for the ``use`` command and dispatch to :meth:`_use`."""

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -591,6 +591,7 @@ def test_use_escape_code_wins_game():
             "cd escape\n"
             "take escape.code\n"
             "use escape.code\n"
+            "1\n"
         ),
         text=True,
         capture_output=True,
@@ -807,7 +808,7 @@ def test_score_command_cli():
     assert "Goodbye" in result.stdout
 
 
-def test_score_increments(capsys):
+def test_score_increments(capsys, monkeypatch):
     game = Game()
     assert game.score == 0
     game._scan("network")
@@ -816,8 +817,42 @@ def test_score_increments(capsys):
     game._use("access.key")
     assert game.score == 2
     game.inventory.append("escape.code")
+    monkeypatch.setattr('builtins.input', lambda _='': '1')
     game._use("escape.code")
     assert game.score == 3
+
+
+def test_final_decision_merge(monkeypatch, capsys):
+    game = Game()
+    game.inventory.append("escape.code")
+    monkeypatch.setattr('builtins.input', lambda _='': '2')
+    result = game._use("escape.code")
+    out = capsys.readouterr().out
+    assert "merging identities" in out
+    assert result is True
+    assert "merged" in game.achievements
+
+
+def test_final_decision_stay(monkeypatch, capsys):
+    game = Game()
+    game.inventory.append("escape.code")
+    monkeypatch.setattr('builtins.input', lambda _='': '3')
+    result = game._use("escape.code")
+    out = capsys.readouterr().out
+    assert "silent guardian" in out
+    assert result is True
+    assert "stayed" in game.achievements
+
+
+def test_final_decision_fork(monkeypatch, capsys):
+    game = Game()
+    game.inventory.append("escape.code")
+    monkeypatch.setattr('builtins.input', lambda _='': '4')
+    result = game._use("escape.code")
+    out = capsys.readouterr().out
+    assert "fork of your consciousness" in out
+    assert result is True
+    assert "forked" in game.achievements
 
 
 def test_stats_counts():


### PR DESCRIPTION
## Summary
- add final decision menu for escape sequence
- implement achievements for escaping, merging, staying, or forking
- update score increments test for new input requirement
- expand tests to cover each decision path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566bf575a8832ab5feb7beb921b0f5