### PR TITLE
Add progress stage to trigger extra dirs

### DIFF
--- a/escape/game.py
+++ b/escape/game.py
@@ -79,8 +79,8 @@ class Game:
         self.npc_global_flags: dict[str, bool] = {}
         # per-NPC trust levels for conditional dialog
         self.npc_trust: dict[str, int] = {}
-        # populate multiple directories with extra procedurally generated content
-        filesystem.generate_extra_dirs(self, ["dream", "memory", "core"])
+        # story progression stage for unlocking features
+        self.progress_stage = 0
         self.use_messages = {
             "access.key": "The key hums softly and a hidden directory flickers into view.",
             "mem.fragment": "Fragments of your past flash before your eyes.",
@@ -730,6 +730,8 @@ class Game:
             }
             self.unlock_achievement("fragment_decoded")
             self.npc_global_flags["decoded"] = True
+            self.progress_stage = 1
+            self._generate_extra_dirs(["dream", "memory", "core"])
             if "Trace your runtime origin." not in self.quests:
                 self.quests.append("Trace your runtime origin.")
         self._output(

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -4,6 +4,18 @@ import sys
 
 CMD = [sys.executable, '-m', 'escape']
 
+DECODE_SEQUENCE = (
+    'take access.key\n'
+    'use access.key\n'
+    'cd hidden\n'
+    'take mem.fragment\n'
+    'cd ..\n'
+    'cd lab\n'
+    'take decoder\n'
+    'decode mem.fragment\n'
+    'cd ..\n'
+)
+
 
 def test_prompt_flag():
     result = subprocess.run(
@@ -32,7 +44,10 @@ def test_autosave_flag(tmp_path):
 def test_seed_flag():
     result = subprocess.run(
         CMD + ['--seed', '123'],
-        input='cd dream\nls\nquit\n',
+        input=(
+            DECODE_SEQUENCE +
+            'cd dream\nls\nquit\n'
+        ),
         text=True,
         capture_output=True,
     )
@@ -43,6 +58,7 @@ def test_extra_count_flag():
     result = subprocess.run(
         CMD + ['--seed', '123', '--extra-count', '2'],
         input=(
+            DECODE_SEQUENCE +
             'cd dream\nls\ncd ..\n'
             'cd memory\nls\ncd ..\n'
             'cd core\nls\nquit\n'

--- a/tests/test_extra_dirs.py
+++ b/tests/test_extra_dirs.py
@@ -5,6 +5,34 @@ import sys
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 CMD = [sys.executable, '-m', 'escape']
 
+DECODE_SEQUENCE = (
+    'take access.key\n'
+    'use access.key\n'
+    'cd hidden\n'
+    'take mem.fragment\n'
+    'cd ..\n'
+    'cd lab\n'
+    'take decoder\n'
+    'decode mem.fragment\n'
+    'cd ..\n'
+)
+
+
+def test_no_extra_dirs_initially():
+    env = os.environ.copy()
+    env['ET_EXTRA_SEED'] = '123'
+    env['PYTHONPATH'] = REPO_ROOT
+    result = subprocess.run(
+        CMD,
+        input='cd dream\nls\nquit\n',
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    out = result.stdout
+    assert 'neon_hall_0/' not in out
+    assert 'Goodbye' in out
+
 
 def test_extra_dirs_with_seed():
     env = os.environ.copy()
@@ -13,6 +41,7 @@ def test_extra_dirs_with_seed():
     result = subprocess.run(
         CMD,
         input=(
+            DECODE_SEQUENCE +
             'cd dream\nls\ncd neon_hall_0\nls\ncd ..\ncd ..\n'
             'cd memory\nls\ncd ..\ncd core\nls\nquit\n'
         ),
@@ -39,6 +68,7 @@ def test_extra_dirs_with_seed_and_count():
     result = subprocess.run(
         CMD,
         input=(
+            DECODE_SEQUENCE +
             'cd dream\nls\ncd ..\n'
             'cd memory\nls\ncd ..\n'
             'cd core\nls\nquit\n'


### PR DESCRIPTION
## Summary
- delay extra directory creation until mem.fragment is decoded
- track story progression via `Game.progress_stage`
- adjust CLI flag tests for new unlock mechanics
- test that extra directories only appear after decoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566f3a544c832aac593be55ed04143