### PR TITLE
Implement story phase tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ the ``achievements`` command to display any that have been unlocked.
 See [docs/GAME_MECHANICS.md](docs/GAME_MECHANICS.md) for details on scoring and
 the restart command.
 
+## Story Phases
+Progress is also tracked with a ``story_phase`` value on ``Game``. Commands and
+NPCs may check this to unlock certain actions as the narrative unfolds. The
+phase system is described in [docs/STORY_PHASES.md](docs/STORY_PHASES.md).
+
 ## Emotional Feedback
 Reading certain memory logs now changes your avatar's mood. The current
 `emotion_state` starts as `confused` and may become `alarmed` or `hopeful`

--- a/docs/STORY_PHASES.md
+++ b/docs/STORY_PHASES.md
@@ -1,0 +1,23 @@
+# Story Phase Progression
+
+The narrative in **Escape the Terminal** advances through a handful of phases
+tracked by `Game.story_phase`.  Each phase unlocks new areas or dialog and can
+be checked by commands or NPC interactions.
+
+## Phases
+
+1. `INTRO` – Initial state at game start.
+2. `LOGS_READ` – Set when key logs such as `identity.log` or the memory
+   fragment are read and decoded.
+3. `RUNTIME_UNLOCKED` – Achieved after hacking the `runtime` node.
+4. `ENDGAME` – Reached once any of the end sequences execute.
+
+The helper `Game.advance_phase()` moves the current phase forward if the new
+value is greater than the existing one.
+
+## Usage
+
+Command handlers and NPC dialogs may check `game.story_phase` to restrict
+access. For example the guardian NPC only speaks after the runtime has been
+unlocked and the loop code cannot run beforehand.  Directories like `void/`
+are likewise inaccessible until the appropriate phase.

--- a/escape/npc.py
+++ b/escape/npc.py
@@ -45,6 +45,9 @@ def update_quests_after_talk(game: "Game", npc: str) -> None:
 def talk(game: "Game", npc: str) -> None:
     """Converse with an NPC if present in the current directory."""
     location = game.npc_locations.get(npc)
+    if npc == "guardian" and game.story_phase < game.StoryPhase.RUNTIME_UNLOCKED:
+        game._output("You aren't prepared to face the guardian yet.")
+        return
     if location != game.current:
         game._output(f"There is no {npc} here.")
         return


### PR DESCRIPTION
## Summary
- introduce `StoryPhase` enum and `Game.story_phase`
- gate guardian dialog and runtime access based on story phase
- advance phase by decoding logs, hacking runtime, and ending sequences
- document phases in new `STORY_PHASES.md`
- mention phase system in README

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685674fcfb00832a86198fcd4eb654b8