### PR TITLE
Add quantum override item

### DIFF
--- a/escape/data/world.json
+++ b/escape/data/world.json
@@ -327,6 +327,7 @@
     "hypervisor.command": "A privileged command set for manipulating the hypervisor.",
     "quantum.access": "An advanced key enabling entry to quantum subsystems.",
     "security.override": "A backdoor routine for bypassing advanced security.",
+    "quantum.override": "A high-level override for quantum-secured systems.",
     "test.script": "A disposable script used for sandbox experiments.",
     "runtime.log": "A record detailing your own execution environment.",
     "identity.log": "A personal log revealing who you truly are.",

--- a/escape/game.py
+++ b/escape/game.py
@@ -40,7 +40,7 @@ class Game:
         "node8": "master.process",
         "node9": "hypervisor.command",
         "node10": "quantum.access",
-        "node11": "security.override",
+        "node11": "quantum.override",
         "node12": "guardian.key",
         "runtime": "kernel.key",
     }
@@ -868,7 +868,7 @@ class Game:
                 if next_name == "node9":
                     node_data["items"].append("quantum.access")
                 if next_name == "node10":
-                    node_data["items"].append("security.override")
+                    node_data["items"].append("quantum.override")
                 extra_items = (
                     self.deep_network_node.get("dirs", {})
                     .get(next_name, {})

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1132,7 +1132,7 @@ def test_hack_node10_success():
     )
     out = result.stdout
     assert 'Access granted' in out
-    assert 'security.override' in out
+    assert 'quantum.override' in out
     assert 'memory10.log' in out
 
 
@@ -1195,7 +1195,7 @@ def test_scan_node11_after_hack_node10():
     assert 'Discovered node11' in out
 
 
-def test_hack_node11_requires_security_override():
+def test_hack_node11_requires_quantum_override():
     result = subprocess.run(
         CMD,
         input=(
@@ -1252,7 +1252,7 @@ def test_hack_node11_requires_security_override():
         capture_output=True,
     )
     out = result.stdout
-    assert 'You need the security.override to hack this node.' in out
+    assert 'You need the quantum.override to hack this node.' in out
 
 
 def test_hack_node11_success():
@@ -1304,7 +1304,7 @@ def test_hack_node11_success():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'
@@ -1370,7 +1370,7 @@ def test_scan_node12_after_hack_node11():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'
@@ -1434,7 +1434,7 @@ def test_hack_node12_requires_guardian_key():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'
@@ -1500,7 +1500,7 @@ def test_hack_node12_success():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'
@@ -1572,7 +1572,7 @@ def test_scan_runtime_after_hack_node11():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'
@@ -1643,7 +1643,7 @@ def test_hack_runtime_requires_kernel_key():
             'hack node10\n'
             'scan node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'hack node11\n'
             'cd node11\n'
             'take guardian.key\n'
@@ -1713,7 +1713,7 @@ def test_hack_runtime_success():
             'cd node9\n'
             'hack node10\n'
             'cd node10\n'
-            'take security.override\n'
+            'take quantum.override\n'
             'cd ..\n'
             'scan node10\n'
             'cd node10\n'


### PR DESCRIPTION
## Summary
- add `quantum.override` item description
- require `quantum.override` to hack node11
- spawn `quantum.override` when node10 is discovered
- update network tests for new item

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856798e56a0832ab728861df544b9c8